### PR TITLE
everest: Change PSU model from 51EA to 51DA

### DIFF
--- a/configurations/Everest.json
+++ b/configurations/Everest.json
@@ -11,7 +11,7 @@
             "Name": "2300W IBMCFFPS Configuration",
             "Type": "SupportedConfiguration",
             "SupportedType": "PowerSupply",
-            "SupportedModel": "51EA",
+            "SupportedModel": "51DA",
             "RedundantCount": 4,
             "InputVoltage": [
                 220


### PR DESCRIPTION
The supported PSU model should be 51DA for Everest.

Change-Id: Id11f29b3a89c023eca9f1e51859d5627534149d2
Signed-off-by: Adriana Kobylak <anoo@us.ibm.com>