### PR TITLE
Add Ambient Virtual Temperature Sensor

### DIFF
--- a/configurations/Blyth.json
+++ b/configurations/Blyth.json
@@ -33,18 +33,21 @@
             "Thresholds": [
                 {
                     "Direction": "greater than",
+                    "Hysteresis": 3,
                     "Name": "HardShutdown",
                     "Severity": 4,
                     "Value": 58
                 },
                 {
                     "Direction": "greater than",
+                    "Hysteresis": 3,
                     "Name": "SoftShutdown",
                     "Severity": 3,
                     "Value": 53
                 },
                 {
                     "Direction": "greater than",
+                    "Hysteresis": 3,
                     "Name": "Warning",
                     "Severity": 0,
                     "Value": 45

--- a/configurations/Blyth.json
+++ b/configurations/Blyth.json
@@ -33,6 +33,18 @@
             "Thresholds": [
                 {
                     "Direction": "greater than",
+                    "Name": "HardShutdown",
+                    "Severity": 4,
+                    "Value": 58
+                },
+                {
+                    "Direction": "greater than",
+                    "Name": "SoftShutdown",
+                    "Severity": 3,
+                    "Value": 53
+                },
+                {
+                    "Direction": "greater than",
                     "Name": "Warning",
                     "Severity": 0,
                     "Value": 45

--- a/configurations/Blyth.json
+++ b/configurations/Blyth.json
@@ -18,6 +18,28 @@
             "Name": "Ambient 1 Temp",
             "Name1": "Station Pressure",
             "Type": "DPS310"
+        },
+        {
+            "MaxValidInput": 100,
+            "MaxValue": 128,
+            "MinValidInput": 0,
+            "MinValue": -127,
+            "Name": "Ambient Virtual Temp",
+            "Sensors": [
+                "Ambient 0 Temp",
+                "Ambient 1 Temp",
+                "Ambient 2 Temp"
+            ],
+            "Thresholds": [
+                {
+                    "Direction": "greater than",
+                    "Name": "Warning",
+                    "Severity": 0,
+                    "Value": 45
+                }
+            ],
+            "Type": "ModifiedMedian",
+            "Units": "DegreesC"
         }
     ],
     "Name": "Blyth Panel",

--- a/configurations/Storm King.json
+++ b/configurations/Storm King.json
@@ -18,7 +18,42 @@
             "Name": "Ambient 1 Temp",
             "Name1": "Station Pressure",
             "Type": "DPS310"
+        },
+        {
+            "MaxValidInput": 100,
+            "MaxValue": 128,
+            "MinValidInput": 0,
+            "MinValue": -127,
+            "Name": "Ambient Virtual Temp",
+            "Sensors": [
+                "Ambient 0 Temp",
+                "Ambient 1 Temp",
+                "Ambient 2 Temp"
+            ],
+            "Thresholds": [
+                {
+                    "Direction": "greater than",
+                    "Name": "HardShutdown",
+                    "Severity": 4,
+                    "Value": 58
+                },
+                {
+                    "Direction": "greater than",
+                    "Name": "SoftShutdown",
+                    "Severity": 3,
+                    "Value": 53
+                },
+                {
+                    "Direction": "greater than",
+                    "Name": "Warning",
+                    "Severity": 0,
+                    "Value": 45
+                }
+            ],
+            "Type": "ModifiedMedian",
+            "Units": "DegreesC"
         }
+
     ],
     "Name": "Storm King Panel",
     "Probe": "com.ibm.ipzvpd.VINI({'CC': [53, 49, 70, 52]})",

--- a/schemas/legacy.json
+++ b/schemas/legacy.json
@@ -670,6 +670,9 @@
                         "Direction": {
                             "type": "string"
                         },
+                        "Hysteresis": {
+                            "type": "number"
+                        },
                         "Label": {
                             "type": "string"
                         },


### PR DESCRIPTION
Would like to get this in downstream for fan-control testing.

This specifies the parameters for a virtual ambient temperature sensor.
phosphor-virtual-sensor will take this information and create the
virtual sensor.

The virtual sensor takes the readings of three temperature sensors
(TMP275, DPS310, SI7020) on this board to calculate the ambient
temperature. This ambient temperature is published on DBus and will be
used for fan control.

We are using a modified median to calculate this ambient temperature. In
the case of only two valid temperature readings we will use the highest
one - in case the other is too low in error. Otherwise we take the
median value.