### PR TITLE
New JSON file to enable ADC read of Rainier and Everest battery voltage

### DIFF
--- a/configurations/Ingraham.json
+++ b/configurations/Ingraham.json
@@ -1,0 +1,29 @@
+{
+    "Exposes": [
+        {
+            "BridgeGpio": [
+                 {
+                     "Name": "battery-voltage",
+                     "Polarity": "High"
+                 }
+	    ],
+            "Index": 0,
+            "Name": "Battery Voltage",
+            "DevName": "iio-hwmon-battery",
+            "ScaleFactor": 0.4348,
+            "PollRate": 86400,
+            "Thresholds": [
+                {
+                    "Direction": "less than",
+                    "Name": "lower critical",
+                    "Severity": 1,
+                    "Value": 3.0  
+                }
+            ],
+            "Type": "ADC"
+        }
+    ],
+    "Name": "Ingraham Board",
+    "Probe": "com.ibm.ipzvpd.VINI({'CC': [54, 66, 53, 56]})",
+    "Type": "Board"
+}

--- a/configurations/Tola.json
+++ b/configurations/Tola.json
@@ -1,12 +1,12 @@
 {
     "Exposes": [
         {
-            "BridgeGpio": [
+	    "BridgeGpio": [
                  {
                      "Name": "battery-voltage-read-enable",
                      "Polarity": "High"
                  }
-	    ],
+            ],
             "Index": 0,
             "Name": "Battery Voltage",
             "DevName": "iio-hwmon-battery",
@@ -23,7 +23,7 @@
             "Type": "ADC"
         }
     ],
-    "Name": "Ingraham Board",
-    "Probe": "com.ibm.ipzvpd.VINI({'CC': [54, 66, 53, 56]})",
+    "Name": "Tola Board",
+    "Probe": "com.ibm.ipzvpd.VINI({'CC': [50, 69, 51, 53]})",
     "Type": "Board"
 }

--- a/meson.build
+++ b/meson.build
@@ -107,6 +107,7 @@ configs = [
     'IBM 1600W CFFPS.json',
     'IBM 2000W CFFPS.json',
     'IBM 2300W CFFPS.json',
+    'Ingraham.json',
     'Intel Front Panel.json',
     'Kudo_BMC.json',
     'Kudo_Motherboard.json',

--- a/meson.build
+++ b/meson.build
@@ -128,6 +128,7 @@ configs = [
     'Storm King.json',
     'STP Baseboard.json',
     'STP P4000 Chassis.json',
+    'Tola.json',
     'Tyan_S7106_Baseboard.json',
     'WFT Baseboard.json',
 ]

--- a/schemas/legacy.json
+++ b/schemas/legacy.json
@@ -57,6 +57,9 @@
                 "CurrScaleFactor": {
                     "$ref": "#/definitions/Types/CurrScaleFactor"
                 },
+                "DevName": {
+                    "$ref": "#/definitions/Types/DevName"
+                },
                 "Direction": {
                     "$ref": "#/definitions/Types/Direction"
                 },
@@ -467,6 +470,9 @@
             },
             "CurrScaleFactor": {
                 "type": "number"
+            },
+            "DevName": {
+                "type": "string"
             },
             "Direction": {
                 "type": "string"


### PR DESCRIPTION
Presently there is no upstream commit for this addition.

The new files support reading the on-board battery voltage
via GPIO line 42.

ON RAINIER:
Tested: busctl introspect xyz.openbmc_project.EntityManager
/xyz/openbmc_project/inventory/system/board/Ingraham_Board/Battery_Voltage

Tested: busctl introspect xyz.openbmc_project.ADCSensor
/xyz/openbmc_project/sensors/voltage/Battery_Voltage

ON EVEREST:
Tested: busctl introspect xyz.openbmc_project.EntityManager
/xyz/openbmc_project/inventory/system/board/Tola_Board/Battery_Voltage

Tested: busctl introspect xyz.openbmc_project.ADCSensor
/xyz/openbmc_project/sensors/voltage/Battery_Voltage

Signed-off-by: Tom Ippolito <thomas.ippolito@ibm.com>