### PR TITLE
Adjusted battery low trip point for Rainier and Everest systems

### DIFF
--- a/configurations/Ingraham.json
+++ b/configurations/Ingraham.json
@@ -17,7 +17,7 @@
                     "Direction": "less than",
                     "Name": "lower critical",
                     "Severity": 1,
-                    "Value": 3.0  
+                    "Value": 2.45  
                 }
             ],
             "Type": "ADC"

--- a/configurations/Tola.json
+++ b/configurations/Tola.json
@@ -17,7 +17,7 @@
                     "Direction": "less than",
                     "Name": "lower critical",
                     "Severity": 1,
-                    "Value": 3.0  
+                    "Value": 2.45  
                 }
             ],
             "Type": "ADC"


### PR DESCRIPTION
According to the schematics for the Rainier and Everest
systems, adjusted the battery low trip voltage to 2.45V.
A value of 2.45V corresponds to an ADC reading of 1.034V.
The battery low trip threshold was originally set to 3.0V

Files Changed:
Ingraham.json (Rainier System)
Tola.json (Everest System)