### PR TITLE
IBM: Change TMP275 poll rates to 1s

### DIFF
--- a/configurations/Bellavista.json
+++ b/configurations/Bellavista.json
@@ -32,13 +32,15 @@
             "Address": "0x48",
             "Bus": 8,
             "Name": "PCIE 0 Temp",
-            "Type": "TMP75"
+            "Type": "TMP75",
+            "PollRate": 1
         },
         {
             "Address": "0x49",
             "Bus": 8,
             "Name": "PCIE 1 Temp",
-            "Type": "TMP75"
+            "Type": "TMP75",
+            "PollRate": 1
         },
         {
             "Address": "0x11",

--- a/configurations/Blyth.json
+++ b/configurations/Blyth.json
@@ -10,7 +10,8 @@
             "Address": "0x48",
             "Bus": 7,
             "Name": "Ambient 0 Temp",
-            "Type": "TMP75"
+            "Type": "TMP75",
+            "PollRate": 1
         },
         {
             "Address": "0x76",

--- a/configurations/Nisqually.json
+++ b/configurations/Nisqually.json
@@ -32,13 +32,15 @@
             "Address": "0x48",
             "Bus": 8,
             "Name": "PCIE 0 Temp",
-            "Type": "TMP75"
+            "Type": "TMP75",
+            "PollRate": 1
         },
         {
             "Address": "0x4A",
             "Bus": 8,
             "Name": "PCIE 1 Temp",
-            "Type": "TMP75"
+            "Type": "TMP75",
+            "PollRate": 1
         },
         {
             "Address": "0x11",

--- a/configurations/Storm King.json
+++ b/configurations/Storm King.json
@@ -10,7 +10,8 @@
             "Address": "0x48",
             "Bus": 29,
             "Name": "Ambient 0 Temp",
-            "Type": "TMP75"
+            "Type": "TMP75",
+            "PollRate": 1
         },
         {
             "Address": "0x76",


### PR DESCRIPTION
Change the poll rates on the TMP275 temperature sensors to 1 second from the default of .5 seconds.  The poll rates of the SI7020 and DPS310 temperature sensors default to 1s already.
