### PR TITLE
Supported Configuration: Add PowerConfigFullLoad

### DIFF
--- a/configurations/Rainier 1S4U Chassis.json
+++ b/configurations/Rainier 1S4U Chassis.json
@@ -17,7 +17,8 @@
             "InputVoltage": [
                 110,
                 220
-            ]
+            ],
+            "PowerConfigFullLoad": true
         },
         {
             "Name": "1600W IBMCFFPS Configuration",
@@ -27,7 +28,8 @@
             "RedundantCount": 2,
             "InputVoltage": [
                 220
-            ]
+            ],
+            "PowerConfigFullLoad": false
         }
     ],
     "Name": "Rainier 1S4U Chassis",

--- a/configurations/Rainier 2U Chassis.json
+++ b/configurations/Rainier 2U Chassis.json
@@ -17,7 +17,8 @@
             "InputVoltage": [
                 110,
                 220
-            ]
+            ],
+            "PowerConfigFullLoad": false
         },
         {
             "Name": "2000W IBMCFFPS Configuration",
@@ -27,7 +28,8 @@
             "RedundantCount": 2,
             "InputVoltage": [
                 220
-            ]
+            ],
+            "PowerConfigFullLoad": false
         }
     ],
     "Name": "Rainier 2U Chassis",

--- a/configurations/Rainier 4U Chassis.json
+++ b/configurations/Rainier 4U Chassis.json
@@ -16,7 +16,8 @@
             "RedundantCount": 4,
             "InputVoltage": [
                 220
-            ]
+            ],
+            "PowerConfigFullLoad": true
         }
     ],
     "Name": "Rainier 4U Chassis",

--- a/schemas/SupportedConfiguration.json
+++ b/schemas/SupportedConfiguration.json
@@ -47,6 +47,16 @@
                     "items": {
                         "type": "number"
                     }
+                },
+                "PowerConfigFullLoad": {
+                    "description": [
+                        "Indicates if the number of power supplies specified",
+                        "in this configuration is the maximum number that",
+                        "a system supports for the case where a system has",
+                        "models that support two different number of power",
+                        "supplies (example 2 or 4)."
+                    ],
+                    "type": "boolean"
                 }
             },
             "required": [


### PR DESCRIPTION
Add the PowerConfigFullLoad property as an optional property to indicate
the value that the power-config-full-load GPIO should be set to for
systems that support it.

Reference:
https://github.com/openbmc/docs/blob/master/designs/device-tree-gpio-naming.md#power-config-full-load

Change-Id: I107bbbeb147f4f23462e4b2f26adb2d51733b256
Signed-off-by: Adriana Kobylak <anoo@us.ibm.com>