### PR TITLE
Remove PM1735 lower thresholds

### DIFF
--- a/configurations/PM1735.json
+++ b/configurations/PM1735.json
@@ -23,18 +23,6 @@
                     "Name": "upper non critical",
                     "Severity": 0,
                     "Value": 110
-                },
-                {
-                    "Direction": "less than",
-                    "Name": "lower non critical",
-                    "Severity": 0,
-                    "Value": 5
-                },
-                {
-                    "Direction": "less than",
-                    "Name": "lower critical",
-                    "Severity": 1,
-                    "Value": 0
                 }
             ],
             "Type": "NVME1000"


### PR DESCRIPTION
These drives seem to report a temperature value of -17 until some as yet
unknown configuration is done by the host.  Until the NVME sensor code
can detect when the temperatures are valid, just remove the lower
thresholds so there are no errors created.

Signed-off-by: Matt Spinler <spinler@us.ibm.com>
Change-Id: Ib679c4d4e41fe9a5a30b7be5d63ff91a68038358