### PR TITLE
Add relative humidity sensor to 2 IBM cards

### DIFF
--- a/configurations/Blyth.json
+++ b/configurations/Blyth.json
@@ -4,6 +4,7 @@
             "Address": "0x40",
             "Bus": 7,
             "Name": "Ambient 2 Temp",
+            "Name1": "Relative Humidity",
             "Type": "SI7020"
         },
         {

--- a/configurations/Storm King.json
+++ b/configurations/Storm King.json
@@ -4,6 +4,7 @@
             "Address": "0x40",
             "Bus": 29,
             "Name": "Ambient 2 Temp",
+            "Name1": "Relative Humidity",
             "Type": "SI7020"
         },
         {


### PR DESCRIPTION
Add the relative humidity sensor to the Blyth and Storm King.  This
triggers the following sensor to be created:

/xyz/openbmc_project/sensors/humidity/Relative_Humidity

This is in master, though those files after other changes so I couldn't just pull over the commit.

Signed-off-by: Matt Spinler <spinler@us.ibm.com>
Change-Id: I5283f5775b8ecbe3a697db4ae8084f32c8c460da