### PR TITLE
schema: ibm: add default power mode props. schema

### DIFF
--- a/configurations/Everest.json
+++ b/configurations/Everest.json
@@ -16,6 +16,16 @@
             "InputVoltage": [
                 220
             ]
+        },
+        {
+            "EnterUtilizationDwellTime": 240,
+            "EnterUtilizationPercent": 8,
+            "ExitUtilizationDwellTime": 120,
+            "ExitUtilizationPercent": 12,
+            "IdlePowerSaverEnabled": true,
+            "Name": "Default Power Mode Properties",
+            "PowerMode": "MaximumPerformance",
+            "Type": "PowerModeProperties"
         }
     ],
     "Name": "Everest Chassis",

--- a/configurations/Rainier 1S4U Chassis.json
+++ b/configurations/Rainier 1S4U Chassis.json
@@ -30,6 +30,16 @@
                 220
             ],
             "PowerConfigFullLoad": false
+        },
+        {
+            "EnterUtilizationDwellTime": 240,
+            "EnterUtilizationPercent": 8,
+            "ExitUtilizationDwellTime": 120,
+            "ExitUtilizationPercent": 12,
+            "IdlePowerSaverEnabled": true,
+            "Name": "Default Power Mode Properties",
+            "PowerMode": "MaximumPerformance",
+            "Type": "PowerModeProperties"
         }
     ],
     "Name": "Rainier 1S4U Chassis",

--- a/configurations/Rainier 2U Chassis.json
+++ b/configurations/Rainier 2U Chassis.json
@@ -30,6 +30,16 @@
                 220
             ],
             "PowerConfigFullLoad": false
+        },
+        {
+            "EnterUtilizationDwellTime": 240,
+            "EnterUtilizationPercent": 8,
+            "ExitUtilizationDwellTime": 120,
+            "ExitUtilizationPercent": 12,
+            "IdlePowerSaverEnabled": true,
+            "Name": "Default Power Mode Properties",
+            "PowerMode": "MaximumPerformance",
+            "Type": "PowerModeProperties"
         }
     ],
     "Name": "Rainier 2U Chassis",

--- a/configurations/Rainier 4U Chassis.json
+++ b/configurations/Rainier 4U Chassis.json
@@ -18,6 +18,16 @@
                 220
             ],
             "PowerConfigFullLoad": true
+        },
+        {
+            "EnterUtilizationDwellTime": 240,
+            "EnterUtilizationPercent": 8,
+            "ExitUtilizationDwellTime": 120,
+            "ExitUtilizationPercent": 12,
+            "IdlePowerSaverEnabled": true,
+            "Name": "Default Power Mode Properties",
+            "PowerMode": "MaximumPerformance",
+            "Type": "PowerModeProperties"
         }
     ],
     "Name": "Rainier 4U Chassis",

--- a/schemas/IBM.json
+++ b/schemas/IBM.json
@@ -97,6 +97,76 @@
                 "Type",
                 "Names"
             ]
+        },
+        "PowerModeProperties": {
+            "title": "PowerMode Properties",
+            "description": [
+                "The default PowerMode properties for the system"
+            ],
+            "type": "object",
+            "properties": {
+                "PowerMode": {
+                    "description": [
+                        "The default PowerMode to use prior to being set by a user."
+                    ],
+                    "enum": [
+                        "Static",
+                        "PowerSaving",
+                        "MaximumPerformance"
+                    ]
+                },
+                "IdlePowerSaverEnabled": {
+                    "description": [
+                        "Default state of idle power saver mode.",
+                        "Setting to true will enable idle power saver."
+                    ],
+                    "type" : "boolean"
+                },
+                "EnterUtilizationPercent": {
+                    "description": [
+                        "The default percentage of utilization that the system shall",
+                        "be lower than to enter idle power save.",
+                        "The value is in integer percentage values (10 = 10%).",
+                        "EnterUtilizationPercent must be <= ExitUtilizationPercent"
+                    ],
+                    "type": "number",
+                    "minimum": 1,
+                    "maximum": 95
+                },
+                "EnterUtilizationDwellTime": {
+                    "description": [
+                        "The default duration in seconds that the system is below",
+                        "the EnterUtilizationPercent before idle power save is activated."
+                    ],
+                    "type": "number",
+                    "minimum": 10,
+                    "maximum": 600
+                },
+                "ExitUtilizationPercent": {
+                    "description": [
+                        "The default percentage of utilization that the system shall",
+                        "be above in order to exit idle power save.",
+                        "The value is in integer percentage values (10 = 10%).",
+                        "ExitUtilizationPercent must be >= EnterUtilizationPercent"
+                    ],
+                    "type": "number",
+                    "minimum": 5,
+                    "maximum": 95
+                },
+                "ExitUtilizationDwellTime": {
+                    "description": [
+                        "The default duration in seconds that the system is above",
+                        "the ExitUtilizationPercent before idle power save is deactivated."
+                    ],
+                    "type": "number",
+                    "minimum": 10,
+                    "maximum": 600
+                }
+            },
+            "required": [
+                "PowerMode",
+                "IdlePowerSaverEnabled"
+            ]
         }
     }
 }

--- a/schemas/global.json
+++ b/schemas/global.json
@@ -9,6 +9,9 @@
             ],
             "oneOf": [
                 {
+                    "$ref": "IBM.json#/definitions/PowerModeProperties"
+                },
+                {
                     "$ref": "IBM.json#/definitions/IBMCompatibleSystem"
                 },
                 {


### PR DESCRIPTION
Add PowerModeProperties schema to define the factory default power mode
properties of a system:
- Power Mode
- Idle Power Saver Parameters

All of these parameters are part of the version 2021.2 Redfish Schema
Supplement under the ComputerSystem 1.16.0 schema:
For details on the values and descriptions, see the PowerMode and
IdlePowerSaver schemas in the Redfish documentation:
https://www.dmtf.org/sites/default/files/standards/documents/DSP0268_2021.2.pdf

These are the factory default values as defined by the system architect.
All of these parameters are system-wide parameters and are used to
define the operation of that system as it relates to power.

These are the values will be used the first time a system is powered on.
They can also be used if the customer wants to restore these settings to
their factory defaults.

Tested on Everest HW

Signed-off-by: Chris Cain <cjcain@us.ibm.com>
Change-Id: Ie2f3ca74db0c898c6a4f3beed29eda674dfcf5c6