### PR TITLE
Revert "Remove PM1735 lower thresholds (#13)"

### DIFF
--- a/configurations/PM1735.json
+++ b/configurations/PM1735.json
@@ -23,6 +23,18 @@
                     "Name": "upper non critical",
                     "Severity": 0,
                     "Value": 110
+                },
+                {
+                    "Direction": "less than",
+                    "Name": "lower non critical",
+                    "Severity": 0,
+                    "Value": 5
+                },
+                {
+                    "Direction": "less than",
+                    "Name": "lower critical",
+                    "Severity": 1,
+                    "Value": 0
                 }
             ],
             "Type": "NVME1000"


### PR DESCRIPTION
The drives should be fixed now, and we were asked to put this back in to
catch the bad temp if it happens again.

This reverts commit cc21acdd26aa5fdc9a0a6f4075c3351d294eda17.

Change-Id: I3dc1c6d4553ef245dbf7b05ea022ea19d22ef3b2