### PR TITLE
configs:Storm King: Update ambient thresholds

### DIFF
--- a/configurations/Storm King.json
+++ b/configurations/Storm King.json
@@ -37,13 +37,13 @@
                     "Direction": "greater than",
                     "Name": "HardShutdown",
                     "Severity": 4,
-                    "Value": 58
+                    "Value": 53
                 },
                 {
                     "Direction": "greater than",
                     "Name": "SoftShutdown",
                     "Severity": 3,
-                    "Value": 53
+                    "Value": 48
                 },
                 {
                     "Direction": "greater than",


### PR DESCRIPTION
Reduce the `HardShutdown` and `SoftShutdown` thresholds by -5C, which
was determined after thermal chamber testing.

Change-Id: I5bd95b5d6bf66bed6d5e29a58f883bcd841223c1
Signed-off-by: Matthew Barth <msbarth@us.ibm.com>