### PR TITLE
configs: Update RTC battery pin to upstream name

### DIFF
--- a/configurations/Ingraham.json
+++ b/configurations/Ingraham.json
@@ -3,7 +3,7 @@
         {
             "BridgeGpio": [
                  {
-                     "Name": "battery-voltage-read-enable",
+                     "Name": "rtc-battery-voltage-read-enable",
                      "Polarity": "High"
                  }
 	    ],

--- a/configurations/Tola.json
+++ b/configurations/Tola.json
@@ -3,7 +3,7 @@
         {
 	    "BridgeGpio": [
                  {
-                     "Name": "battery-voltage-read-enable",
+                     "Name": "rtc-battery-voltage-read-enable",
                      "Polarity": "High"
                  }
             ],


### PR DESCRIPTION
The name agreed to was rtc-battery-voltage-read-enable.

Signed-off-by: Joel Stanley <joel@jms.id.au>