### PR TITLE
configs: Blyth & Storm King ambient sensor thresholds

### DIFF
--- a/configurations/Blyth.json
+++ b/configurations/Blyth.json
@@ -5,20 +5,66 @@
             "Bus": 7,
             "Name": "Ambient 2 Temp",
             "Name1": "Relative Humidity",
+            "Thresholds": [
+                {
+                    "Direction": "greater than",
+                    "Index": 1,
+                    "Name": "Ambient Upper Critical",
+                    "Severity": 0,
+                    "Value": 100
+                },
+                {
+                    "Direction": "less than",
+                    "Index": 1,
+                    "Name": "Ambient Lower Critical",
+                    "Severity": 0,
+                    "Value": 0
+                }
+            ],
             "Type": "SI7020"
         },
         {
             "Address": "0x48",
             "Bus": 7,
             "Name": "Ambient 0 Temp",
-            "Type": "TMP75",
-            "PollRate": 1
+            "PollRate": 1,
+            "Thresholds": [
+                {
+                    "Direction": "greater than",
+                    "Name": "Ambient Upper Critical",
+                    "Severity": 0,
+                    "Value": 100
+                },
+                {
+                    "Direction": "less than",
+                    "Name": "Ambient Lower Critical",
+                    "Severity": 0,
+                    "Value": 0
+                }
+            ],
+            "Type": "TMP75"
         },
         {
             "Address": "0x76",
             "Bus": 7,
             "Name": "Ambient 1 Temp",
             "Name1": "Station Pressure",
+            "Thresholds": [
+                {
+                    "Direction": "greater than",
+                    "Index": 1,
+                    "Name": "Ambient Upper Critical",
+                    "Severity": 0,
+                    "Value": 100
+                },
+                {
+                    "Direction": "less than",
+                    "Index": 1,
+                    "Name": "Ambient Lower Critical",
+                    "Severity": 0,
+                    "Value": 0
+                }
+            ],
             "Type": "DPS310"
         },
         {

--- a/configurations/Storm King.json
+++ b/configurations/Storm King.json
@@ -5,20 +5,66 @@
             "Bus": 29,
             "Name": "Ambient 2 Temp",
             "Name1": "Relative Humidity",
+            "Thresholds": [
+                {
+                    "Direction": "greater than",
+                    "Index": 1,
+                    "Name": "Ambient Upper Critical",
+                    "Severity": 0,
+                    "Value": 100
+                },
+                {
+                    "Direction": "less than",
+                    "Index": 1,
+                    "Name": "Ambient Lower Critical",
+                    "Severity": 0,
+                    "Value": 0
+                }
+            ],
             "Type": "SI7020"
         },
         {
             "Address": "0x48",
             "Bus": 29,
             "Name": "Ambient 0 Temp",
-            "Type": "TMP75",
-            "PollRate": 1
+            "PollRate": 1,
+            "Thresholds": [
+                {
+                    "Direction": "greater than",
+                    "Name": "Ambient Upper Critical",
+                    "Severity": 0,
+                    "Value": 100
+                },
+                {
+                    "Direction": "less than",
+                    "Name": "Ambient Lower Critical",
+                    "Severity": 0,
+                    "Value": 0
+                }
+            ],
+            "Type": "TMP75"
         },
         {
             "Address": "0x76",
             "Bus": 29,
             "Name": "Ambient 1 Temp",
             "Name1": "Station Pressure",
+            "Thresholds": [
+                {
+                    "Direction": "greater than",
+                    "Index": 1,
+                    "Name": "Ambient Upper Critical",
+                    "Severity": 0,
+                    "Value": 100
+                },
+                {
+                    "Direction": "less than",
+                    "Index": 1,
+                    "Name": "Ambient Lower Critical",
+                    "Severity": 0,
+                    "Value": 0
+                }
+            ],
             "Type": "DPS310"
         },
         {


### PR DESCRIPTION
Include warning thresholds on each of the ambient sensors so that an
error is logged if a reading from each sensor is either above 100C or
below 0C.

Change-Id: I160c0291743da988a9951c902112845d9791a094
Signed-off-by: Matthew Barth <msbarth@us.ibm.com>