### PR TITLE
configs:ibm: Rename PCIe card temp sensors

### DIFF
--- a/configurations/Bear Lake.json
+++ b/configurations/Bear Lake.json
@@ -3,8 +3,8 @@
         {
             "Address": "$address % 4 + 76",
             "Bus": "$bus",
-            "Name": "PCIe Cable Card $index Local Temp",
-            "Name1": "PCIe Cable Card $index Temp",
+            "Name": "PCIe Cable Card C$slotnumber Local Temp",
+            "Name1": "PCIe Cable Card C$slotnumber Temp",
             "Type": "TMP435",
             "PowerStateOwner": "PCIeSlot",
             "LocationCode": "$locationcode",
@@ -20,7 +20,7 @@
             ]
         }
     ],
-    "Name": "4U PCIe Cable Card $index",
+    "Name": "4U PCIe Cable Card C$slotnumber",
     "Probe": "com.ibm.ipzvpd.VINI({'CC': [54, 66, 57, 57]})",
     "Type": "Board"
 }

--- a/configurations/Bear River.json
+++ b/configurations/Bear River.json
@@ -3,8 +3,8 @@
         {
             "Address": "$address % 4 + 76",
             "Bus": "$bus",
-            "Name": "PCIe Cable Card $index Local Temp",
-            "Name1": "PCIe Cable Card $index Temp",
+            "Name": "PCIe Cable Card C$slotnumber Local Temp",
+            "Name1": "PCIe Cable Card C$slotnumber Temp",
             "Type": "TMP435",
             "PowerStateOwner": "PCIeSlot",
             "LocationCode": "$locationcode",
@@ -20,7 +20,7 @@
             ]
         }
     ],
-    "Name": "2U PCIe Cable Card $index",
+    "Name": "2U PCIe Cable Card C$slotnumber",
     "Probe": "com.ibm.ipzvpd.VINI({'CC': [54, 66, 57, 50]})",
     "Type": "Board"
 }

--- a/configurations/Flett.json
+++ b/configurations/Flett.json
@@ -3,8 +3,8 @@
         {
             "Address": "$address % 4 + 76",
             "Bus": "$bus",
-            "Name": "NVMe JBOF Card $index Local Temp",
-            "Name1": "NVMe JBOF Card $index Temp",
+            "Name": "NVMe JBOF Card C$slotnumber Local Temp",
+            "Name1": "NVMe JBOF Card C$slotnumber Temp",
             "Type": "TMP435",
             "PowerStateOwner": "PCIeSlot",
             "LocationCode": "$locationcode",
@@ -20,7 +20,7 @@
             ]
         }
     ],
-    "Name": "NVMe JBOF Card $index",
+    "Name": "NVMe JBOF Card C$slotnumber",
     "Probe": "com.ibm.ipzvpd.VINI({'CC': [54, 66, 56, 55]})",
     "Type": "Board"
 }


### PR DESCRIPTION
This commit gives the NVMe JBOF and PCIe cable card temp sensors a
stable name, so associations can be made to their corresponding D-Bus
objects in phosphor-inventory-manager (e.g.
.../motherboard/pcie_slot10/pciecard10).

The location code segment is used as the unique identifier of the sensor
names, like NVMe_JBOF_Card_C11_Temp.

The $slotnumber variable comes from the SlotNumber D-Bus property on the
inventory-manager's D-Bus object for the card.

Needs https://github.ibm.com/openbmc/openbmc/pull/1965 to merge first as that provides the SlotNumber property.

Signed-off-by: Matt Spinler <spinler@us.ibm.com>
Change-Id: If98bbd5842e940fde6e3afd7f63439bc0a6dc854