### PR TITLE
Narrow D-Bus matches

### DIFF
--- a/src/EntityManager.cpp
+++ b/src/EntityManager.cpp
@@ -1079,7 +1079,8 @@ int main()
     // entities from DBus.
     sdbusplus::bus::match::match nameOwnerChangedMatch(
         static_cast<sdbusplus::bus::bus&>(*systemBus),
-        sdbusplus::bus::match::rules::nameOwnerChanged(),
+        sdbusplus::bus::match::rules::nameOwnerChanged(
+            "xyz.openbmc_project.Inventory.Manager"),
         [&](sdbusplus::message::message&) {
             propertiesChangedCallback(systemConfiguration, objServer);
         });
@@ -1087,13 +1088,15 @@ int main()
     // destroyed.
     sdbusplus::bus::match::match interfacesAddedMatch(
         static_cast<sdbusplus::bus::bus&>(*systemBus),
-        sdbusplus::bus::match::rules::interfacesAdded(),
+        sdbusplus::bus::match::rules::interfacesAdded(
+            "/xyz/openbmc_project/inventory"),
         [&](sdbusplus::message::message&) {
             propertiesChangedCallback(systemConfiguration, objServer);
         });
     sdbusplus::bus::match::match interfacesRemovedMatch(
         static_cast<sdbusplus::bus::bus&>(*systemBus),
-        sdbusplus::bus::match::rules::interfacesRemoved(),
+        sdbusplus::bus::match::rules::interfacesRemoved(
+            "/xyz/openbmc_project/inventory"),
         [&](sdbusplus::message::message&) {
             propertiesChangedCallback(systemConfiguration, objServer);
         });


### PR DESCRIPTION
This commit restricts the NameOwnerChanged, InterfacesAdded and
InterfacesRemoved matches to the PIM service and the objects with
inventory prefix.

On IBM systems, the only configurations currently in use come from
PIM. Too broad of a match seems to lockup the event loop where the
code that actually places EM configuration on D-Bus never gets a chance
to run. This can happen, for example, when there are several PELs being
created.

Ideally, I think we need to be able to configure EM (preferably at build
time) to match only certain services/paths.

Signed-off-by: Santosh Puranik <santosh.puranik@in.ibm.com>