### PR TITLE
entity-manager: Failsafe for scan callback timer

### DIFF
--- a/src/EntityManager.cpp
+++ b/src/EntityManager.cpp
@@ -36,6 +36,7 @@
 #include <sdbusplus/asio/object_server.hpp>
 
 #include <charconv>
+#include <chrono>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
@@ -927,18 +928,30 @@ void propertiesChangedCallback(nlohmann::json& systemConfiguration,
     static size_t instance = 0;
     instance++;
     size_t count = instance;
+    static auto startTime = std::chrono::time_point_cast<std::chrono::seconds>(
+        std::chrono::steady_clock::now());
 
-    timer.expires_after(std::chrono::seconds(5));
+    if (0 == timer.expires_after(std::chrono::seconds(5)))
+    {
+        // Reset start time if there were no async waits queued
+        startTime = std::chrono::time_point_cast<std::chrono::seconds>(
+            std::chrono::steady_clock::now());
+    }
 
     // setup an async wait as we normally get flooded with new requests
     timer.async_wait([&systemConfiguration, &objServer,
                       count](const boost::system::error_code& ec) {
-        if (ec == boost::asio::error::operation_aborted)
+        auto endTime = std::chrono::time_point_cast<std::chrono::seconds>(
+            std::chrono::steady_clock::now());
+        std::chrono::duration<int> elapsed = endTime - startTime;
+
+        if ((ec == boost::asio::error::operation_aborted) &&
+            elapsed < std::chrono::seconds(15))
         {
             // we were cancelled
             return;
         }
-        if (ec)
+        if (ec && ec != boost::asio::error::operation_aborted)
         {
             std::cerr << "async wait error " << ec << "\n";
             return;
@@ -950,6 +963,10 @@ void propertiesChangedCallback(nlohmann::json& systemConfiguration,
             return;
         }
         inProgress = true;
+
+        // Reset start time when we get a chance to run
+        startTime = std::chrono::time_point_cast<std::chrono::seconds>(
+            std::chrono::steady_clock::now());
 
         nlohmann::json oldConfiguration = systemConfiguration;
         auto missingConfigurations = std::make_shared<nlohmann::json>();


### PR DESCRIPTION
The propertiesChangedCallback has a 5s idle timer. The purpose of
this timer is to prevent a flood of D-Bus signals that the callback
reacts to from causing rescans too quickly.

However, if we have rogue applications generating, for example,
an InterfacesAdded signal say every 2s, the 5s timer keeps getting
restarted, causing entity manager to never actually run the scan.

This commit adds a fail-safe that keeps us from looping in the timer
restarts forever by forcing a scan when 15s elapse. The start time to
measure these 15s is reset every time we either get a chance to scan or
when the 5s timer is not running.

Ideally, we would want to look into a design where we could be more
restrictive of the signals that entity manager responds to, but that is
probably a long-term solution.

Tested:

I tested by using a command line app that causes an InterfacesAdded
signal every 1s in a loop. Verified that EM performs the scan every 15s.

Signed-off-by: Santosh Puranik <santosh.puranik@in.ibm.com>