### PR TITLE
schema: ibm: correct ExitUtilizationDwellTime

### DIFF
--- a/configurations/Everest.json
+++ b/configurations/Everest.json
@@ -20,7 +20,7 @@
         {
             "EnterUtilizationDwellTime": 240,
             "EnterUtilizationPercent": 8,
-            "ExitUtilizationDwellTime": 120,
+            "ExitUtilizationDwellTime": 10,
             "ExitUtilizationPercent": 12,
             "IdlePowerSaverEnabled": true,
             "Name": "Default Power Mode Properties",

--- a/configurations/Rainier 1S4U Chassis.json
+++ b/configurations/Rainier 1S4U Chassis.json
@@ -34,7 +34,7 @@
         {
             "EnterUtilizationDwellTime": 240,
             "EnterUtilizationPercent": 8,
-            "ExitUtilizationDwellTime": 120,
+            "ExitUtilizationDwellTime": 10,
             "ExitUtilizationPercent": 12,
             "IdlePowerSaverEnabled": true,
             "Name": "Default Power Mode Properties",

--- a/configurations/Rainier 2U Chassis.json
+++ b/configurations/Rainier 2U Chassis.json
@@ -34,7 +34,7 @@
         {
             "EnterUtilizationDwellTime": 240,
             "EnterUtilizationPercent": 8,
-            "ExitUtilizationDwellTime": 120,
+            "ExitUtilizationDwellTime": 10,
             "ExitUtilizationPercent": 12,
             "IdlePowerSaverEnabled": true,
             "Name": "Default Power Mode Properties",

--- a/configurations/Rainier 4U Chassis.json
+++ b/configurations/Rainier 4U Chassis.json
@@ -22,7 +22,7 @@
         {
             "EnterUtilizationDwellTime": 240,
             "EnterUtilizationPercent": 8,
-            "ExitUtilizationDwellTime": 120,
+            "ExitUtilizationDwellTime": 10,
             "ExitUtilizationPercent": 12,
             "IdlePowerSaverEnabled": true,
             "Name": "Default Power Mode Properties",


### PR DESCRIPTION
The ExitUtilizationDwellTime should be using a default of 10 seconds.
When the utilization of the system goes above the ExitUtilizationPercent
the system should exit the idle state quickly to return performance to
the users. The previous value of 120 seconds would delay exiting idle
state by 2 minutes.

Signed-off-by: Chris Cain <cjcain@us.ibm.com>
Change-Id: Ie2f3ca74db0c898c6a4f3beed29eda674dfcf5c6