### PR TITLE
configurations: Fix misleading drive model name

### DIFF
--- a/configurations/generic_nvme_drive.json
+++ b/configurations/generic_nvme_drive.json
@@ -4,13 +4,13 @@
         {
             "Address": "$address",
             "Bus": "$bus",
-            "Name": "Samsung PM1735 $index FRU",
+            "Name": "NVMe $index FRU",
             "Type": "EEPROM"
         },
         {
             "Address": "0x6a",
             "Bus": "$bus",
-            "Name": "Samsung PM1735 $index Temp",
+            "Name": "NVMe $index Temp",
             "Thresholds": [
                 {
                     "Direction": "greater than",
@@ -29,12 +29,12 @@
         }
     ],
     "Logging": "Off",
-    "Name": "Samsung PM1735 $index",
+    "Name": "NVMe $index",
     "Probe": "com.ibm.ipzvpd.VINI({'CC': [78, 86, 77, 101]})",
     "Type": "NVMe",
     "xyz.openbmc_project.Inventory.Decorator.Asset": {
-        "Manufacturer": "Samsung",
-        "Model": "PM1735",
+        "Manufacturer": "Unknown",
+        "Model": "NVMe",
         "PartNumber": "$PN",
         "SerialNumber": "$SN"
     }

--- a/meson.build
+++ b/meson.build
@@ -124,7 +124,7 @@ configs = [
     'Nisqually.json',
     'NVME P4000.json',
     'PCIE SSD Retimer.json',
-    'PM1735.json',
+    'generic_nvme_drive.json',
     'PSSF132202A.json',
     'PSSF162205A.json',
     'PSSF212201A.json',


### PR DESCRIPTION
We don't know the model of the drives exposed by platform-fru-detect, so
don't pretend we do.

Must not be merged before integration of https://github.com/ibm-openbmc/phosphor-fan-presence/pull/11 into ibm-openbmc/openbmc