### PR TITLE
EntityManager: Associate configs with their DBus probe source

### DIFF
--- a/include/EntityManager.hpp
+++ b/include/EntityManager.hpp
@@ -65,6 +65,12 @@ using FoundProbeTypeT =
                                              CmpStr>::const_iterator>;
 FoundProbeTypeT findProbeType(const std::string& probe);
 
+struct ConfigurationRelation
+{
+    nlohmann::json systemConfiguration;
+    nlohmann::json probeObjectPaths;
+};
+
 struct PerformScan : std::enable_shared_from_this<PerformScan>
 {
 

--- a/include/Utils.hpp
+++ b/include/Utils.hpp
@@ -26,6 +26,16 @@
 #include <fstream>
 #include <iostream>
 
+template <typename P, typename M>
+static inline P* containerOf(M* ptr, const M P::*member)
+{
+    auto inner = reinterpret_cast<intptr_t>(ptr);
+    auto offset =
+        reinterpret_cast<ptrdiff_t>(&(reinterpret_cast<P*>(0)->*member));
+    auto outer = reinterpret_cast<P*>(inner - offset);
+    return outer;
+}
+
 constexpr const char* configurationOutDir = "/var/configuration/";
 constexpr const char* versionHashFile = "/var/configuration/version";
 constexpr const char* versionFile = "/etc/os-release";

--- a/src/PerformScan.cpp
+++ b/src/PerformScan.cpp
@@ -22,6 +22,7 @@
 #include <boost/container/flat_set.hpp>
 
 #include <charconv>
+#include <functional>
 
 /* Hacks from splitting EntityManager.cpp */
 extern std::shared_ptr<sdbusplus::asio::connection> systemBus;
@@ -590,6 +591,18 @@ void PerformScan::run()
                     // overwrite ourselves with cleaned up version
                     _systemConfiguration[recordName] = record;
                     _missingConfigurations.erase(recordName);
+
+                    auto* cr = containerOf(
+                        &_systemConfiguration,
+                        &ConfigurationRelation::systemConfiguration);
+                    auto pathKey =
+                        std::to_string(std::hash<std::string>{}(record.dump()));
+                    cr->probeObjectPaths[pathKey] = path;
+                    if constexpr (debug) {
+                        std::cerr << "Registered path " << path << " with pathKey "
+                                  << pathKey << " for configuration "
+                                  << record.dump() << "\n";
+                    }
                 }
             });
 


### PR DESCRIPTION
Allow dynamic inventory associations to be added to sensors by reactors
in the context of our Frankenstein's monster of a PIM/EM combo.

The disconnect in the EM data model between where we know about the path of
the object that triggered the probe and where we publish the probed
configuration on DBus drives some complexity in the implementation. To
bridge that gap we need to create a bit of a wormhole through the
codebase. An alternative to making a wormhole is to inject the path
metadata straight into the EM data model, but that requires more
analysis than I have time or intestinal fortitude for right now.

The wormhole we create is built on a spiritual reimplementation of
Linux's container_of() macro. By embedding the systemConfiguration in a
struct we can reach up from its pointer and back down into another
member of the same struct which stores the probe path for a given
configuration. This is an improvement on adding another global into the
sea that we already have as globals provide no intuitive relationship
between eachother. By contrast, gathering related data into a struct
provides a much stronger intuitive relationship.

Signed-off-by: Andrew Jeffery <andrew@aj.id.au>
Change-Id: I98e137f7159113d89fe790206595955b6f311154