### PR TITLE
configs:ibm: Virtual ambient hysteresis updates

### DIFF
--- a/configurations/Blyth.json
+++ b/configurations/Blyth.json
@@ -81,7 +81,7 @@
             "Thresholds": [
                 {
                     "Direction": "greater than",
-                    "Hysteresis": 3,
+                    "Hysteresis": 50,
                     "Name": "HardShutdown",
                     "Severity": 4,
                     "Value": 58

--- a/configurations/Storm King.json
+++ b/configurations/Storm King.json
@@ -81,18 +81,21 @@
             "Thresholds": [
                 {
                     "Direction": "greater than",
+                    "Hysteresis": 50,
                     "Name": "HardShutdown",
                     "Severity": 4,
                     "Value": 53
                 },
                 {
                     "Direction": "greater than",
+                    "Hysteresis": 3,
                     "Name": "SoftShutdown",
                     "Severity": 3,
                     "Value": 48
                 },
                 {
                     "Direction": "greater than",
+                    "Hysteresis": 3,
                     "Name": "Warning",
                     "Severity": 0,
                     "Value": 45


### PR DESCRIPTION
Made a few updates related to the hysteresis values on the virtual
ambient temperature sensor on the Storm King and Blyth panels.

1) Added them to the Warning and SoftShutdown thresholds on Storm King,
   where they were missing.  Used a value of 3.

2) For the HardShutdown thresholds on both Storm King and Blyth, used a
   hysteresis of 50 to make it high enough to ensure the hard shutdown
   isn't cancellable since it isn't built into the sensor monitor code.

   In practice this probably isn't likely to matter much as the delay
   before the shutdown is only 23 seconds, and also PHYP was already
   told to shutdown the box after the SoftShutdown threshold was
   crossed.

Signed-off-by: Matt Spinler <spinler@us.ibm.com>
Change-Id: I7b21f1af2f8667e3ded4b06cffd458e8743e619d