### PR TITLE
Add support for 110v input voltage on 2000W power supply

### DIFF
--- a/configurations/Rainier 2U Chassis.json
+++ b/configurations/Rainier 2U Chassis.json
@@ -27,6 +27,7 @@
             "SupportedModel": "51E9",
             "RedundantCount": 2,
             "InputVoltage": [
+                110,
                 220
             ],
             "PowerConfigFullLoad": false


### PR DESCRIPTION
Update supported configuration to allow 110v imput voltage on the 2000W
power supply in the Rainier 2U system.

Signed-off-by: Jim Wright <jlwright@us.ibm.com>