### PR TITLE
Add name to InventoryAdded/Removed journal entries

### DIFF
--- a/include/EntityManager.hpp
+++ b/include/EntityManager.hpp
@@ -119,6 +119,7 @@ inline void logDeviceAdded(const nlohmann::json& record)
     std::string model = "Unknown";
     std::string type = "Unknown";
     std::string sn = "Unknown";
+    std::string name = "Unknown";
 
     if (findType != record.end())
     {
@@ -146,10 +147,17 @@ inline void logDeviceAdded(const nlohmann::json& record)
         }
     }
 
-    sd_journal_send("MESSAGE=%s", "Inventory Added", "PRIORITY=%i", LOG_ERR,
-                    "REDFISH_MESSAGE_ID=%s", "OpenBMC.0.1.InventoryAdded",
+    auto findName = record.find("Name");
+    if (findName != record.end())
+    {
+        name = findName->get<std::string>();
+    }
+
+    sd_journal_send("MESSAGE=Inventory Added: %s", name.c_str(), "PRIORITY=%i",
+                    LOG_INFO, "REDFISH_MESSAGE_ID=%s",
+                    "OpenBMC.0.1.InventoryAdded",
                     "REDFISH_MESSAGE_ARGS=%s,%s,%s", model.c_str(),
-                    type.c_str(), sn.c_str(), NULL);
+                    type.c_str(), sn.c_str(), "NAME=%s", name.c_str(), NULL);
 }
 
 inline void logDeviceRemoved(const nlohmann::json& record)
@@ -165,6 +173,7 @@ inline void logDeviceRemoved(const nlohmann::json& record)
     std::string model = "Unknown";
     std::string type = "Unknown";
     std::string sn = "Unknown";
+    std::string name = "Unknown";
 
     if (findType != record.end())
     {
@@ -192,8 +201,15 @@ inline void logDeviceRemoved(const nlohmann::json& record)
         }
     }
 
-    sd_journal_send("MESSAGE=%s", "Inventory Removed", "PRIORITY=%i", LOG_ERR,
-                    "REDFISH_MESSAGE_ID=%s", "OpenBMC.0.1.InventoryRemoved",
+    auto findName = record.find("Name");
+    if (findName != record.end())
+    {
+        name = findName->get<std::string>();
+    }
+
+    sd_journal_send("MESSAGE=Inventory Removed: %s", name.c_str(),
+                    "PRIORITY=%i", LOG_INFO, "REDFISH_MESSAGE_ID=%s",
+                    "OpenBMC.0.1.InventoryRemoved",
                     "REDFISH_MESSAGE_ARGS=%s,%s,%s", model.c_str(),
-                    type.c_str(), sn.c_str(), NULL);
+                    type.c_str(), sn.c_str(), "NAME=%s", name.c_str(), NULL);
 }


### PR DESCRIPTION
Add the name of the inventory item into the journal messages that print when inventory adds or removes occur so that it's obvious which part is being referred to.

Journal output:
entity-manager[3395]: Inventory Added: Blyth Panel

And in the journal metadata:
NAME=Blyth Panel

This also picks up the upstream change to have these be INFO traces.

This merged upstream with 200bf40ee9f03d715500b41b6128a61991f9243e.

Signed-off-by: Matt Spinler <spinler@us.ibm.com>
Change-Id: I7ce351e72831c69f3f927486350142dd466aa630