### PR TITLE
ignore unique-name dbus connections

### DIFF
--- a/src/EntityManager.cpp
+++ b/src/EntityManager.cpp
@@ -634,7 +634,7 @@ void postToDbus(const nlohmann::json& newConfiguration,
             {
                 auto* cr =
                     containerOf(&systemConfiguration,
-                                 &ConfigurationRelation::systemConfiguration);
+                                &ConfigurationRelation::systemConfiguration);
                 auto pathKey = std::to_string(
                     std::hash<std::string>{}(boardPair.value().dump()));
                 if (cr->probeObjectPaths.contains(pathKey))
@@ -645,18 +645,21 @@ void postToDbus(const nlohmann::json& newConfiguration,
                         values = {{"probed_by", "probes", path}};
                     associationIface->register_property("Associations", values);
                     associationIface->initialize();
-                    if constexpr (debug) {
-                        std::cerr << "Added association interface to path " << path
-                            << " from pathKey " << pathKey << " on "
-                            << boardName << " for configuration "
-                            << boardPair.value().dump() << "\n";
+                    if constexpr (debug)
+                    {
+                        std::cerr << "Added association interface to path "
+                                  << path << " from pathKey " << pathKey
+                                  << " on " << boardName
+                                  << " for configuration "
+                                  << boardPair.value().dump() << "\n";
                     }
                 }
                 else
                 {
-                    if constexpr (debug) {
-                        std::cerr << "No registered path for pathKey " << pathKey
-                                  << "\n";
+                    if constexpr (debug)
+                    {
+                        std::cerr << "No registered path for pathKey "
+                                  << pathKey << "\n";
                     }
                 }
             }
@@ -1136,7 +1139,16 @@ int main()
     sdbusplus::bus::match::match nameOwnerChangedMatch(
         static_cast<sdbusplus::bus::bus&>(*systemBus),
         sdbusplus::bus::match::rules::nameOwnerChanged(),
-        [&](sdbusplus::message::message&) {
+        [&](sdbusplus::message::message& m) {
+            std::string name;
+            m.read(name);
+
+            if (name.starts_with(':'))
+            {
+                // We should do nothing with unique-name connections.
+                return;
+            }
+
             propertiesChangedCallback(system.systemConfiguration, objServer);
         });
     // We also need a poke from DBus when new interfaces are created or


### PR DESCRIPTION
Unique-named dbus connections should not be exposing dbus objects and are created by dbus clients (if only an unnamed connection exists). Filter these out in order to reduce the re-scanning effort in entity-manager.

On some systems with a high number shell-script driven `busctl` operations, this was reported to have a net performance benefit.  I ran this on Bletchley hardware and observed a small (<1sec) boot time performance, which was difficult to distinguish from the noise.

Tested: Ran on Bletchley and observed identical EM `busctl tree`.

Signed-off-by: Patrick Williams <patrick@stwcx.xyz>
Change-Id: I08b1fe87665312e9bab019f7bff748e03cdc0027