### PR TITLE
Allow 2 PS in Rainier 1s4u 1000W configuration

### DIFF
--- a/configurations/Rainier 1S4U Chassis.json
+++ b/configurations/Rainier 1S4U Chassis.json
@@ -13,7 +13,7 @@
             "Type": "SupportedConfiguration",
             "SupportedType": "PowerSupply",
             "SupportedModel": "2B1D",
-            "RedundantCount": 4,
+            "RedundantCount": 2,
             "InputVoltage": [
                 110,
                 220


### PR DESCRIPTION
Support has been added for Rainier 1s4u systems with 1000W power supplies to run with only two power supplies. Change the redundant count in this configuration to support.

Signed-off-by: Jim Wright <jlwright@us.ibm.com>