### PR TITLE
For/1050/forward port

### DIFF
--- a/include/entity_manager.hpp
+++ b/include/entity_manager.hpp
@@ -62,6 +62,12 @@ using FoundProbeTypeT =
                                              CmpStr>::const_iterator>;
 FoundProbeTypeT findProbeType(const std::string& probe);
 
+struct ConfigurationRelation
+{
+    nlohmann::json systemConfiguration;
+    nlohmann::json probeObjectPaths;
+};
+
 struct PerformScan : std::enable_shared_from_this<PerformScan>
 {
 

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -26,6 +26,19 @@
 #include <fstream>
 #include <iostream>
 
+template <typename P, typename M>
+static inline P* containerOf(M* ptr, const M P::*member)
+{
+    // NOLINTBEGIN(cppcoreguidelines-pro-type-reinterpret-cast)
+    auto inner = reinterpret_cast<intptr_t>(ptr);
+    auto offset =
+        reinterpret_cast<ptrdiff_t>(&(reinterpret_cast<P*>(0)->*member));
+    // NOLINTNEXTLINE(performance-no-int-to-ptr)
+    auto outer = reinterpret_cast<P*>(inner - offset);
+    return outer;
+    // NOLINTEND(cppcoreguidelines-pro-type-reinterpret-cast)
+}
+
 constexpr const char* configurationOutDir = "/var/configuration/";
 constexpr const char* versionHashFile = "/var/configuration/version";
 constexpr const char* versionFile = "/etc/os-release";

--- a/src/entity_manager.cpp
+++ b/src/entity_manager.cpp
@@ -44,6 +44,9 @@
 #include <map>
 #include <regex>
 #include <variant>
+
+constexpr const bool debug = false;
+
 constexpr const char* hostConfigurationDirectory = SYSCONF_DIR "configurations";
 constexpr const char* configurationDirectory = PACKAGE_DIR "configurations";
 constexpr const char* schemaDirectory = PACKAGE_DIR "configurations/schemas";
@@ -616,6 +619,44 @@ void postToDbus(const nlohmann::json& newConfiguration,
 
             populateInterfaceFromJson(systemConfiguration, jsonPointerPath,
                                       boardIface, boardValues, objServer);
+
+            std::shared_ptr<sdbusplus::asio::dbus_interface> associationIface =
+                createInterface(objServer, boardName,
+                                "xyz.openbmc_project.Association.Definitions",
+                                boardKeyOrig);
+
+            {
+                auto* cr =
+                    containerOf(&systemConfiguration,
+                                &ConfigurationRelation::systemConfiguration);
+                auto pathKey = std::to_string(
+                    std::hash<std::string>{}(boardConfig.dump()));
+                if (cr->probeObjectPaths.contains(pathKey))
+                {
+                    auto& path = cr->probeObjectPaths[pathKey];
+                    std::vector<
+                        std::tuple<std::string, std::string, std::string>>
+                        values = {{"probed_by", "probes", path}};
+                    associationIface->register_property("Associations", values);
+                    associationIface->initialize();
+                    if constexpr (debug)
+                    {
+                        std::cerr << "Added association interface to path "
+                                  << path << " from pathKey " << pathKey
+                                  << " on " << boardName
+                                  << " for configuration " << boardConfig.dump()
+                                  << "\n";
+                    }
+                }
+                else
+                {
+                    if constexpr (debug)
+                    {
+                        std::cerr << "No registered path for pathKey "
+                                  << pathKey << "\n";
+                    }
+                }
+            }
         }
 
         jsonPointerPath += "/";
@@ -1116,7 +1157,10 @@ int main()
     // to keep reference to the match / filter objects so they don't get
     // destroyed
 
-    nlohmann::json systemConfiguration = nlohmann::json::object();
+    ConfigurationRelation system;
+
+    system.systemConfiguration = nlohmann::json::object();
+    system.probeObjectPaths = nlohmann::json::object();
 
     // We need a poke from DBus for static providers that create all their
     // objects prior to claiming a well-known name, and thus don't emit any
@@ -1136,7 +1180,7 @@ int main()
                 return;
             }
 
-            propertiesChangedCallback(systemConfiguration, objServer);
+            propertiesChangedCallback(system.systemConfiguration, objServer);
         });
     // We also need a poke from DBus when new interfaces are created or
     // destroyed.
@@ -1144,20 +1188,21 @@ int main()
         static_cast<sdbusplus::bus_t&>(*systemBus),
         sdbusplus::bus::match::rules::interfacesAdded(),
         [&](sdbusplus::message_t&) {
-            propertiesChangedCallback(systemConfiguration, objServer);
+            propertiesChangedCallback(system.systemConfiguration, objServer);
         });
     sdbusplus::bus::match_t interfacesRemovedMatch(
         static_cast<sdbusplus::bus_t&>(*systemBus),
         sdbusplus::bus::match::rules::interfacesRemoved(),
         [&](sdbusplus::message_t&) {
-            propertiesChangedCallback(systemConfiguration, objServer);
+            propertiesChangedCallback(system.systemConfiguration, objServer);
         });
 
-    io.post(
-        [&]() { propertiesChangedCallback(systemConfiguration, objServer); });
+    io.post([&]() {
+        propertiesChangedCallback(system.systemConfiguration, objServer);
+    });
 
     entityIface->register_method("ReScan", [&]() {
-        propertiesChangedCallback(systemConfiguration, objServer);
+        propertiesChangedCallback(system.systemConfiguration, objServer);
     });
     entityIface->initialize();
 

--- a/src/perform_scan.cpp
+++ b/src/perform_scan.cpp
@@ -495,9 +495,13 @@ void PerformScan::updateSystemConfiguration(const nlohmann::json& recordRef,
 
             pruneRecordExposes(*record);
 
-            recordDiscoveredIdentifiers(usedNames, indexes, probeName, *record);
-
-            _systemConfiguration[recordName] = *record;
+            // Only cache the config if it contains no template parameters
+            if (*record == recordRef)
+            {
+                recordDiscoveredIdentifiers(usedNames, indexes, probeName,
+                                            *record);
+                _systemConfiguration[recordName] = *record;
+            }
         }
         _missingConfigurations.erase(recordName);
 

--- a/src/perform_scan.cpp
+++ b/src/perform_scan.cpp
@@ -22,6 +22,7 @@
 #include <boost/container/flat_set.hpp>
 
 #include <charconv>
+#include <functional>
 
 /* Hacks from splitting entity_manager.cpp */
 extern std::shared_ptr<sdbusplus::asio::connection> systemBus;
@@ -584,6 +585,17 @@ void PerformScan::updateSystemConfiguration(const nlohmann::json& recordRef,
         // overwrite ourselves with cleaned up version
         _systemConfiguration[recordName] = record;
         _missingConfigurations.erase(recordName);
+
+        auto* cr = containerOf(&_systemConfiguration,
+                               &ConfigurationRelation::systemConfiguration);
+        auto pathKey = std::to_string(std::hash<std::string>{}(record.dump()));
+        cr->probeObjectPaths[pathKey] = path;
+        if constexpr (debug)
+        {
+            std::cerr << "Registered path " << path << " with pathKey "
+                      << pathKey << " for configuration " << record.dump()
+                      << "\n";
+        }
     }
 }
 


### PR DESCRIPTION
Forward-port patches from 1020 to 1050. These fix issues with e.g. NVMe drives being moved between slots, and automatically adding sensor/inventory associations.