### PR TITLE
Revert "PerformScan: Don't insert cached value for templated configs (#32)

### DIFF
--- a/src/perform_scan.cpp
+++ b/src/perform_scan.cpp
@@ -496,13 +496,9 @@ void PerformScan::updateSystemConfiguration(const nlohmann::json& recordRef,
 
             pruneRecordExposes(*record);
 
-            // Only cache the config if it contains no template parameters
-            if (*record == recordRef)
-            {
-                recordDiscoveredIdentifiers(usedNames, indexes, probeName,
-                                            *record);
-                _systemConfiguration[recordName] = *record;
-            }
+            recordDiscoveredIdentifiers(usedNames, indexes, probeName, *record);
+
+            _systemConfiguration[recordName] = *record;
         }
         _missingConfigurations.erase(recordName);
 


### PR DESCRIPTION
This reverts commit 8880238fe1e259f94e638a03e60788f5674f5cf2.

It was found that this was causing inventory to go missing every other restart of entity-manager. That's clearly not the intended effect, so back the change out in preparation to reconsider the approach.

Signed-off-by: Andrew Jeffery <andrew@aj.id.au>