### PR TITLE
PerformScan: Don't insert cached value for templated configs (#32)

### DIFF
--- a/src/perform_scan.cpp
+++ b/src/perform_scan.cpp
@@ -494,6 +494,14 @@ void PerformScan::updateSystemConfiguration(const nlohmann::json& recordRef,
                 continue;
             }
 
+            // If the config contains template parameters then ignore the cached
+            // config
+            if (*record != recordRef)
+            {
+                itr++;
+                continue;
+            }
+
             pruneRecordExposes(*record);
 
             recordDiscoveredIdentifiers(usedNames, indexes, probeName, *record);


### PR DESCRIPTION
We don't retain enough information to know that the cached record is valid in the context of the properties collected on the most recent scan. As such, if the config is templated, skip injecting the cached record.

Regenerating the configuration in the context of the newly gathered data prevents e.g. publishing stale I2C data gathered from xyz.openbmc_project.Inventory.Decorator.I2CDevice which is often not the interface that triggered the probe. This last fact is is important, because the record name generated by entity-manager for use in the cache lookup is only based on the information captured in the interface triggering the probe statement. Thus if a device is moved between slots the fact that we don't account for slot-specific information causes a false hit.

Change-Id: Ibbcaa84b8e51685ffbe1c009c4fd93867f55c8fd
Signed-off-by: Andrew Jeffery <andrew@aj.id.au>