### PR TITLE
configurations: Add Bonnell power supplies

### DIFF
--- a/configurations/bonnell.json
+++ b/configurations/bonnell.json
@@ -6,6 +6,17 @@
                 "ibm,bonnell"
             ],
             "Type": "IBMCompatibleSystem"
+        },
+        {
+            "InputVoltage": [
+                110,
+                220
+            ],
+            "Name": "800W IBMCFFPS Configuration",
+            "RedundantCount": 2,
+            "SupportedModel": "FPG0",
+            "SupportedType": "PowerSupply",
+            "Type": "SupportedConfiguration"
         }
     ],
     "Name": "Bonnell Chassis",


### PR DESCRIPTION
Add IBM's Bonnell 800W power supplies to entity manager configuration.

Tested: Bonnell simulation using busctl command
busctl introspect  xyz.openbmc_project.EntityManager /xyz/openbmc_project/inventory/system/chassis/Bonnell_Chassis/800W_IBMCFFPS_Configuration
NAME                                                     TYPE
SIGNATURE RESULT/VALUE                  FLAGS
xyz.openbmc_project.Configuration.SupportedConfiguration interface -
-                             -
.InputVoltage                                            property  at
2 110 220                     emits-change
.Name                                                    property  s
"800W IBMCFFPS Configuration" emits-change
.RedundantCount                                          property  t
2                             emits-change
.SupportedModel                                          property  s
"FPG0"                        emits-change
.SupportedType                                           property  s
"PowerSupply"                 emits-change
.Type                                                    property  s
"SupportedConfiguration"      emits-change

Change-Id: Ia4d48fce6a2f2c754a51849ee07547670b7c015e