### PR TITLE
configuration: Fix Bonnell PSU I2C addresses

### DIFF
--- a/configurations/pennybacker.json
+++ b/configurations/pennybacker.json
@@ -1,14 +1,14 @@
 {
     "Exposes": [
         {
-            "I2CAddress": 88,
+            "I2CAddress": 91,
             "I2CBus": 3,
             "Name": "Power Supply Slot 0",
             "NamedPresenceGpio": "presence-ps0",
             "Type": "IBMCFFPSConnector"
         },
         {
-            "I2CAddress": 89,
+            "I2CAddress": 90,
             "I2CBus": 3,
             "Name": "Power Supply Slot 1",
             "NamedPresenceGpio": "presence-ps1",


### PR DESCRIPTION
Fix the Bonnell Power Supply I2C addresses.

Change-Id: I7ae6f625c009fe0c79a8e95f33540a75f662fcee