### PR TITLE
configs: Add battery config to pennybacker

### DIFF
--- a/configurations/pennybacker.json
+++ b/configurations/pennybacker.json
@@ -1,6 +1,27 @@
 {
     "Exposes": [
         {
+            "BridgeGpio": [
+                {
+                    "Name": "rtc-battery-voltage-read-enable",
+                    "Polarity": "High"
+                }
+            ],
+            "Index": 0,
+            "Name": "Battery Voltage",
+            "PollRate": 86400,
+            "ScaleFactor": 0.4348,
+            "Thresholds": [
+                {
+                    "Direction": "less than",
+                    "Name": "lower critical",
+                    "Severity": 1,
+                    "Value": 2.45
+                }
+            ],
+            "Type": "ADC"
+        },
+        {
             "I2CAddress": 91,
             "I2CBus": 3,
             "Name": "Power Supply Slot 0",


### PR DESCRIPTION
Add the config for ADCSensor to read the RTC battery voltage on IBM's Pennybacker board.

Tested:
Sensor was on D-Bus with a value of 3.0819 Volts.


Change-Id: If468f15de2ad10fded8c1ef85bf0b2f4dd230a47