### PR TITLE
Trace object path on FileExists crashes

### DIFF
--- a/src/entity_manager.cpp
+++ b/src/entity_manager.cpp
@@ -606,8 +606,17 @@ void postToDbus(const nlohmann::json& newConfiguration,
             createInterface(objServer, boardName,
                             "xyz.openbmc_project.Inventory.Item", boardKey);
 
-        createAddObjectMethod(jsonPointerPath, boardName, systemConfiguration,
-                              objServer, boardKeyOrig);
+        try
+        {
+            createAddObjectMethod(jsonPointerPath, boardName,
+                                  systemConfiguration, objServer, boardKeyOrig);
+        }
+        catch (const sdbusplus::exception_t&)
+        {
+            std::cerr << "Failed creating AddObject method on " << boardName
+                      << "\n";
+            throw;
+        }
 
         if (boardType != "Chassis")
         {


### PR DESCRIPTION
Bugs in either an entity-manager config file or in code that hosts D-Bus properties that entity-manager probes can cause it to try to create the same object path on D-Bus twice.  When this happens, it will crash with an unhandled org.freedesktop.DBus.Error.FileExists exception when it tries to create the second xyz.openbmc_project.AddObject interface on the path.

It isn't always that easy to figure out which object path it failed on - it requires either using gdb on the core dump or looking for duplicate Name fields in /var/configuration/system.json.

This commits makes it obvious by catching the initial exception, tracing the object path in the journal, and then rethrowing.  The new trace is the first one below:

```
entity-manager[14753]: Failed creating AddObject method on /xyz/openbmc_project/inventory/system/board/Test_Card
entity-manager[14753]: terminate called after throwing an instance of 'sdbusplus::exception::SdBusError'
entity-manager[14753]:   what():  sd_bus_add_object_vtable: org.freedesktop.DBus.Error.FileExists: File exists
```


Change-Id: I7f8a97dfa57caa6f0cc1e9f11f9807e9d29d050a