### PR TITLE
schema: ibm: add default power mode props. for Bonnell

### DIFF
--- a/configurations/bonnell.json
+++ b/configurations/bonnell.json
@@ -8,6 +8,16 @@
             "Type": "IBMCompatibleSystem"
         },
         {
+            "EnterUtilizationDwellTime": 240,
+            "EnterUtilizationPercent": 8,
+            "ExitUtilizationDwellTime": 10,
+            "ExitUtilizationPercent": 12,
+            "IdlePowerSaverEnabled": true,
+            "Name": "Default Power Mode Properties",
+            "PowerMode": "MaximumPerformance",
+            "Type": "PowerModeProperties"
+        },
+        {
             "InputVoltage": [
                 110,
                 220


### PR DESCRIPTION
Define default Power Mode and IPS paramenters for Bonnell systems

Change-Id: I70ba27f6c51afb8c6309ad94bbd8c32fe630967a