### PR TITLE
Change ambient temp hard shutdown hysteresis

### DIFF
--- a/configurations/Blyth.json
+++ b/configurations/Blyth.json
@@ -81,7 +81,7 @@
             "Thresholds": [
                 {
                     "Direction": "greater than",
-                    "Hysteresis": 50,
+                    "Hysteresis": 3,
                     "Name": "HardShutdown",
                     "Severity": 4,
                     "Value": 58

--- a/configurations/Storm King.json
+++ b/configurations/Storm King.json
@@ -81,7 +81,7 @@
             "Thresholds": [
                 {
                     "Direction": "greater than",
-                    "Hysteresis": 50,
+                    "Hysteresis": 3,
                     "Name": "HardShutdown",
                     "Severity": 4,
                     "Value": 53


### PR DESCRIPTION
The hysteresis value on the hard shutdown threshold on the virtual ambient was artificially high to prevent the hard shutdown from being canceled by the temp going down, because it's referred to as an 'EPOW4 alert' inside IBM and that shutdown is not supposed to be canceled ever if it gets that hot.

However the problem with such a big hysteresis is even on the next boot when the temp is back to room temp it won't have crossed that hysteresis value so will just shut down again.

So, just change it back to what it was previously, 3, and in a future release I'll change the sensor monitor code to make that shutdown uncancellable.  It's pretty unlikely the temp would drop by that much in the 23 seconds before the hard shutdown anyway, and we'd still be in the process of having the host shut down from the EPOW notification anyway.


Change-Id: Ie7290d9831de4e0b2febbb21d72703be2549c2f1