### PR TITLE
1060: schemas: Add Decorator.Compatible interface & Use common Polarity in schema & configs: Add Compatible iface to IBM systems

### DIFF
--- a/configurations/bonnell.json
+++ b/configurations/bonnell.json
@@ -33,5 +33,10 @@
     "Probe": [
         "com.ibm.ipzvpd.VSBP({'IM': [80, 0, 64, 0]})"
     ],
-    "Type": "Chassis"
+    "Type": "Chassis",
+    "xyz.openbmc_project.Inventory.Decorator.Compatible": {
+        "Names": [
+            "com.ibm.Hardware.Chassis.Model.Bonnell"
+        ]
+    }
 }

--- a/configurations/everest.json
+++ b/configurations/everest.json
@@ -32,5 +32,10 @@
     "Probe": [
         "com.ibm.ipzvpd.VSBP({'IM': [80, 0, 48, 0]})"
     ],
-    "Type": "Chassis"
+    "Type": "Chassis",
+    "xyz.openbmc_project.Inventory.Decorator.Compatible": {
+        "Names": [
+            "com.ibm.Hardware.Chassis.Model.Everest"
+        ]
+    }
 }

--- a/configurations/rainier_1s4u_chassis.json
+++ b/configurations/rainier_1s4u_chassis.json
@@ -46,5 +46,11 @@
     "Probe": [
         "com.ibm.ipzvpd.VSBP({'IM': [80, 0, 16, 2]})"
     ],
-    "Type": "Chassis"
+    "Type": "Chassis",
+    "xyz.openbmc_project.Inventory.Decorator.Compatible": {
+        "Names": [
+            "com.ibm.Hardware.Chassis.Model.Rainier1S4U",
+            "com.ibm.Hardware.Chassis.Model.Rainier"
+        ]
+    }
 }

--- a/configurations/rainier_2u_chassis.json
+++ b/configurations/rainier_2u_chassis.json
@@ -49,5 +49,11 @@
         "OR",
         "com.ibm.ipzvpd.VSBP({'IM': [80, 0, 16, 3]})"
     ],
-    "Type": "Chassis"
+    "Type": "Chassis",
+    "xyz.openbmc_project.Inventory.Decorator.Compatible": {
+        "Names": [
+            "com.ibm.Hardware.Chassis.Model.Rainier2U",
+            "com.ibm.Hardware.Chassis.Model.Rainier"
+        ]
+    }
 }

--- a/configurations/rainier_4u_chassis.json
+++ b/configurations/rainier_4u_chassis.json
@@ -34,5 +34,11 @@
     "Probe": [
         "com.ibm.ipzvpd.VSBP({'IM': [80, 0, 16, 0]})"
     ],
-    "Type": "Chassis"
+    "Type": "Chassis",
+    "xyz.openbmc_project.Inventory.Decorator.Compatible": {
+        "Names": [
+            "com.ibm.Hardware.Chassis.Model.Rainier4U",
+            "com.ibm.Hardware.Chassis.Model.Rainier"
+        ]
+    }
 }

--- a/schemas/global.json
+++ b/schemas/global.json
@@ -141,6 +141,9 @@
                 "xyz.openbmc_project.Inventory.Decorator.AssetTag": {
                     "$ref": "openbmc-dbus.json#/definitions/xyz/openbmc_project/Inventory/Decorator/AssetTag"
                 },
+                "xyz.openbmc_project.Inventory.Decorator.Compatible": {
+                    "$ref": "openbmc-dbus.json#/definitions/xyz/openbmc_project/Inventory/Decorator/Compatible"
+                },
                 "xyz.openbmc_project.Inventory.Item.Board.Motherboard": {
                     "$ref": "openbmc-dbus.json#/definitions/xyz/openbmc_project/Inventory/Item/Board/Motherboard"
                 },

--- a/schemas/legacy.json
+++ b/schemas/legacy.json
@@ -603,7 +603,7 @@
                 "type": "number"
             },
             "Polarity": {
-                "type": "string"
+                "enum": ["High", "Low"]
             },
             "Polling": {
                 "type": "object"
@@ -630,7 +630,7 @@
                         "type": "string"
                     },
                     "Polarity": {
-                        "enum": "Low"
+                        "$ref": "#/definitions/Types/Polarity"
                     }
                 },
                 "type": "object"

--- a/schemas/openbmc-dbus.json
+++ b/schemas/openbmc-dbus.json
@@ -39,6 +39,19 @@
                             },
                             "required": ["AssetTag"],
                             "type": "object"
+                        },
+                        "Compatible": {
+                            "additionalProperties": false,
+                            "properties": {
+                                "Names": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "required": ["Names"],
+                            "type": "object"
                         }
                     },
                     "Item": {


### PR DESCRIPTION
#### schemas: Add Decorator.Compatible interface
```
This commit adds Compatible to under xyz.openbmc_project.Decorator in
openbmc-dbus.json with property Names as described in
https://github.com/openbmc/phosphor-dbus-interfaces/blob/master/yaml/\
xyz/openbmc_project/Inventory/Decorator/Compatible.interface.yaml. This
commit also adds xyz.openbmc_project.Inventory.Decorator.Compatible to
under EMConfig in global.json so that the interface can be configured in
the board's Entity Manager configuration file. The usage of this
interface was mentioned in
https://github.com/openbmc/phosphor-dbus-interfaces/blob/master/yaml/\
xyz/openbmc_project/Software/README.md#compatibility.

Signed-off-by: Chau Ly <chaul@amperecomputing.com>
Change-Id: I447dacb3ffb8dc0dede5d3b17e58cbe06804e214
```
#### Use common Polarity in schema
```
Point the definition of the Polarity property in the Presence entry at
the common Polarity definition, and also make that an enum since that is
how all code uses it.

Recently, CI started failing without this change, though why it started
failing is a mystery to me, and the error messages aren't that helpful.

Signed-off-by: Matt Spinler <spinler@us.ibm.com>
Change-Id: I966974b894a715c563bed3823a6b47b92a7ee94a
```
#### configs: Add Compatible iface to IBM systems
```
Add the xyz.openbmc_project.Inventory.Decorator.Compatible interface to
the IBM chassis configs to identify the various chassis models.

This acts the same as the IBMCompatibleSystem interface that is
currently used and will eventually replace it.  For now it will exist
along side it until all of the code switches over to use it, and then
IBMCompatibleSystem will be removed.

Tested:
```
busctl get-property xyz.openbmc_project.EntityManager \
/xyz/openbmc_project/inventory/system/chassis/Rainier_2U_Chassis \
xyz.openbmc_project.Inventory.Decorator.Compatible Names

as 2 "com.ibm.Hardware.Chassis.Model.Rainier2U" "com.ibm.Hardware.Chassis.Model.Rainier"
```

Change-Id: Iac9b45f57e53c4ed1917c5fc10091b2ccf981d58
Signed-off-by: Matt Spinler <spinler@us.ibm.com>
```