### PR TITLE
EM fixes for 1110

### DIFF
--- a/configurations/generic_nvme_drive.json
+++ b/configurations/generic_nvme_drive.json
@@ -2,12 +2,6 @@
     "Bus": "$bus",
     "Exposes": [
         {
-            "Address": "$address",
-            "Bus": "$bus",
-            "Name": "NVMe $index FRU",
-            "Type": "EEPROM"
-        },
-        {
             "Address": "0x6a",
             "Bus": "$bus",
             "Name": "NVMe $index Temp",

--- a/src/entity_manager.cpp
+++ b/src/entity_manager.cpp
@@ -646,7 +646,7 @@ void postToDbus(const nlohmann::json& newConfiguration,
 
         std::shared_ptr<sdbusplus::asio::dbus_interface> inventoryIface =
             createInterface(objServer, boardPath,
-                            "xyz.openbmc_project.Inventory.Item", boardName);
+                            "xyz.openbmc_project.Inventory.Item", boardNameOrig);
 
         createAddObjectMethod(jsonPointerPath, boardPath, systemConfiguration,
                               objServer, boardNameOrig);
@@ -672,7 +672,8 @@ void postToDbus(const nlohmann::json& newConfiguration,
                 {
                     auto& path = cr->probeObjectPaths[pathKey];
                     Association values{"probed_by", "probes", path};
-                    saveAssociation(boardPath, boardName, values, associations);
+                    saveAssociation(boardPath, boardNameOrig, values,
+                                    associations);
 
                     if constexpr (debug)
                     {


### PR DESCRIPTION
Remove an EEPROM stanza that IBM doesn't use from the NVMe config file.
Also fix how the  associations interface is stored in the interface map so that it can actually be deleted when a FRU is removed.

These are only downstream problems.