### PR TITLE
configuration: system1: Add GPIO monitoring type

### DIFF
--- a/configurations/system1_chassis.json
+++ b/configurations/system1_chassis.json
@@ -5,10 +5,11 @@
             "BindConnector": "Fan1 connector",
             "Bus": 6,
             "Index": 0,
-            "MaxReading": 36200,
+            "MaxReading": 14500,
             "Name": "Fan1a_in",
             "PowerState": "Always",
             "Presence": {
+                "MonitorType": "Polling",
                 "PinName": "FAN0_PRESENCE_R_N",
                 "Polarity": "Low"
             },
@@ -45,9 +46,14 @@
             "BindConnector": "Fan1 connector",
             "Bus": 6,
             "Index": 1,
-            "MaxReading": 0,
+            "MaxReading": 14500,
             "Name": "Fan1b_in",
             "PowerState": "Always",
+            "Presence": {
+                "MonitorType": "Polling",
+                "PinName": "FAN0_PRESENCE_R_N",
+                "Polarity": "Low"
+            },
             "Thresholds": [
                 {
                     "Direction": "less than",
@@ -81,10 +87,11 @@
             "BindConnector": "Fan2 connector",
             "Bus": 6,
             "Index": 2,
-            "MaxReading": 0,
+            "MaxReading": 14500,
             "Name": "Fan2a_in",
             "PowerState": "Always",
             "Presence": {
+                "MonitorType": "Polling",
                 "PinName": "FAN1_PRESENCE_R_N",
                 "Polarity": "Low"
             },
@@ -121,9 +128,14 @@
             "BindConnector": "Fan2 connector",
             "Bus": 6,
             "Index": 3,
-            "MaxReading": 0,
+            "MaxReading": 14500,
             "Name": "Fan2b_in",
             "PowerState": "Always",
+            "Presence": {
+                "MonitorType": "Polling",
+                "PinName": "FAN1_PRESENCE_R_N",
+                "Polarity": "Low"
+            },
             "Thresholds": [
                 {
                     "Direction": "less than",
@@ -157,10 +169,11 @@
             "BindConnector": "Fan3 connector",
             "Bus": 6,
             "Index": 4,
-            "MaxReading": 0,
+            "MaxReading": 14500,
             "Name": "Fan3a_in",
             "PowerState": "Always",
             "Presence": {
+                "MonitorType": "Polling",
                 "PinName": "FAN2_PRESENCE_R_N",
                 "Polarity": "Low"
             },
@@ -197,9 +210,14 @@
             "BindConnector": "Fan3 connector",
             "Bus": 6,
             "Index": 5,
-            "MaxReading": 0,
+            "MaxReading": 14500,
             "Name": "Fan3b_in",
             "PowerState": "Always",
+            "Presence": {
+                "MonitorType": "Polling",
+                "PinName": "FAN2_PRESENCE_R_N",
+                "Polarity": "Low"
+            },
             "Thresholds": [
                 {
                     "Direction": "less than",
@@ -233,10 +251,11 @@
             "BindConnector": "Fan4 connector",
             "Bus": 6,
             "Index": 6,
-            "MaxReading": 0,
+            "MaxReading": 14500,
             "Name": "Fan4a_in",
             "PowerState": "Always",
             "Presence": {
+                "MonitorType": "Polling",
                 "PinName": "FAN3_PRESENCE_R_N",
                 "Polarity": "Low"
             },
@@ -273,9 +292,14 @@
             "BindConnector": "Fan4 connector",
             "Bus": 6,
             "Index": 7,
-            "MaxReading": 0,
+            "MaxReading": 14500,
             "Name": "Fan4b_in",
             "PowerState": "Always",
+            "Presence": {
+                "MonitorType": "Polling",
+                "PinName": "FAN3_PRESENCE_R_N",
+                "Polarity": "Low"
+            },
             "Thresholds": [
                 {
                     "Direction": "less than",
@@ -309,10 +333,11 @@
             "BindConnector": "Fan5 connector",
             "Bus": 6,
             "Index": 8,
-            "MaxReading": 0,
+            "MaxReading": 14500,
             "Name": "Fan5a_in",
             "PowerState": "Always",
             "Presence": {
+                "MonitorType": "Polling",
                 "PinName": "FAN4_PRESENCE_R_N",
                 "Polarity": "Low"
             },
@@ -349,9 +374,14 @@
             "BindConnector": "Fan5 connector",
             "Bus": 6,
             "Index": 9,
-            "MaxReading": 0,
+            "MaxReading": 14500,
             "Name": "Fan5b_in",
             "PowerState": "Always",
+            "Presence": {
+                "MonitorType": "Polling",
+                "PinName": "FAN4_PRESENCE_R_N",
+                "Polarity": "Low"
+            },
             "Thresholds": [
                 {
                     "Direction": "less than",
@@ -385,10 +415,11 @@
             "BindConnector": "Fan6 connector",
             "Bus": 6,
             "Index": 0,
-            "MaxReading": 0,
+            "MaxReading": 25000,
             "Name": "Fan6_in",
             "PowerState": "Always",
             "Presence": {
+                "MonitorType": "Polling",
                 "PinName": "FAN5_PRESENCE_N",
                 "Polarity": "Low"
             },
@@ -425,10 +456,11 @@
             "BindConnector": "Fan7 connector",
             "Bus": 6,
             "Index": 1,
-            "MaxReading": 0,
+            "MaxReading": 25000,
             "Name": "Fan7_in",
             "PowerState": "Always",
             "Presence": {
+                "MonitorType": "Polling",
                 "PinName": "FAN6_PRESENCE_N",
                 "Polarity": "Low"
             },
@@ -691,7 +723,8 @@
             "ILimitMin": 2500,
             "Inputs": [
                 "Ambient 0 Temp",
-                "Ambient 1 Temp"
+                "Ambient 1 Temp",
+                "Ambient 2 Temp"
             ],
             "Name": "Ambient Temperature",
             "NegativeHysteresis": 0,
@@ -709,14 +742,44 @@
             ]
         },
         {
+            "Class": "temp",
+            "FFGainCoefficient": 0,
+            "FFOffCoefficient": 0,
+            "ICoefficient": -5,
+            "ILimitMax": 18000,
+            "ILimitMin": 2500,
+            "Inputs": [
+                "PCIE_SWITCH1_TEMP",
+                "PCIE_SWITCH2_TEMP",
+                "PCIE_SWITCH3_TEMP",
+                "PCIE_SWITCH4_TEMP",
+                "PCIE_SWITCH5_TEMP",
+                "PCIE_SWITCH6_TEMP"
+            ],
+            "Name": "PCIE Switch Temperature",
+            "NegativeHysteresis": 0,
+            "OutLimitMax": 18000,
+            "OutLimitMin": 2500,
+            "Outputs": [],
+            "PCoefficient": -500,
+            "PositiveHysteresis": 0,
+            "SetPoint": 85,
+            "SlewNeg": 0,
+            "SlewPos": 0,
+            "Type": "Pid",
+            "Zones": [
+                "CECIO"
+            ]
+        },
+        {
             "FailSafePercent": 100,
-            "MinThermalOutput": 2500,
+            "MinThermalOutput": 8800,
             "Name": "CECIO",
             "Type": "Pid.Zone"
         },
         {
             "FailSafePercent": 100,
-            "MinThermalOutput": 2500,
+            "MinThermalOutput": 10000,
             "Name": "NVME",
             "Type": "Pid.Zone"
         }

--- a/schemas/legacy.json
+++ b/schemas/legacy.json
@@ -1008,6 +1008,9 @@
             },
             "Presence": {
                 "properties": {
+                    "MonitorType": {
+                        "enum": ["Event", "Polling"]
+                    },
                     "PinName": {
                         "type": "string"
                     },


### PR DESCRIPTION
Some GPIOs do not support event_read method to monitor for value changes. Added a new MonitorType field to specify if the GPIO needs to be manually polled to detect presence.
Also added PCIE Switch temperature sensors

Tested:
- Verified no change when MonitorType not specified
- Verified functionality when Polling enum was specified

Change-Id: Ie5e8a2afe43d05192828292b629baade6b0c9c82