### PR TITLE
configs: Use known num in generic_nvme_drive

### DIFF
--- a/configurations/generic_nvme_drive.json
+++ b/configurations/generic_nvme_drive.json
@@ -4,13 +4,13 @@
         {
             "Address": "$address",
             "Bus": "$bus",
-            "Name": "NVMe $index FRU",
+            "Name": "NVMe $SlotNumber FRU",
             "Type": "EEPROM"
         },
         {
             "Address": "0x6a",
             "Bus": "$bus",
-            "Name": "NVMe $index Temp",
+            "Name": "NVMe $SlotNumber Temp",
             "Thresholds": [
                 {
                     "Direction": "greater than",
@@ -29,7 +29,7 @@
         }
     ],
     "Logging": "Off",
-    "Name": "NVMe $index",
+    "Name": "NVMe $SlotNumber",
     "Probe": "com.ibm.ipzvpd.VINI({'CC': [78, 86, 77, 101]})",
     "Type": "NVMe",
     "xyz.openbmc_project.Inventory.Decorator.Asset": {


### PR DESCRIPTION
Don't use $index in the D-Bus names, because EM can get confused by platform-fru-detect interactions and tries to put two instances of the same object path on D-Bus and will crash.

Instead use SlotNumber, which is a property on the xyz.openbmc_project.Inventory.Decorator.Slot interface that will be on D-Bus on the drive inventory-manager path.


Change-Id: I76b6bd5183a50a6c265bc151880c10adc7213a88