### PR TITLE
configuration: system1: Fix fan indexing problem

### DIFF
--- a/configurations/system1_chassis.json
+++ b/configurations/system1_chassis.json
@@ -43,9 +43,173 @@
         },
         {
             "Address": "0x52",
-            "BindConnector": "Fan1 connector",
+            "BindConnector": "Fan2 connector",
             "Bus": 6,
             "Index": 1,
+            "MaxReading": 14500,
+            "Name": "Fan2a_in",
+            "PowerState": "Always",
+            "Presence": {
+                "MonitorType": "Polling",
+                "PinName": "FAN1_PRESENCE_R_N",
+                "Polarity": "Low"
+            },
+            "Thresholds": [
+                {
+                    "Direction": "less than",
+                    "Name": "lower critical",
+                    "Severity": 1,
+                    "Value": 0
+                },
+                {
+                    "Direction": "less than",
+                    "Name": "lower non critical",
+                    "Severity": 0,
+                    "Value": 1800
+                },
+                {
+                    "Direction": "greater than",
+                    "Name": "upper critical",
+                    "Severity": 1,
+                    "Value": 36200
+                },
+                {
+                    "Direction": "greater than",
+                    "Name": "upper non critical",
+                    "Severity": 0,
+                    "Value": 28960
+                }
+            ],
+            "Type": "I2CFan"
+        },
+        {
+            "Address": "0x52",
+            "BindConnector": "Fan3 connector",
+            "Bus": 6,
+            "Index": 2,
+            "MaxReading": 14500,
+            "Name": "Fan3a_in",
+            "PowerState": "Always",
+            "Presence": {
+                "MonitorType": "Polling",
+                "PinName": "FAN2_PRESENCE_R_N",
+                "Polarity": "Low"
+            },
+            "Thresholds": [
+                {
+                    "Direction": "less than",
+                    "Name": "lower critical",
+                    "Severity": 1,
+                    "Value": 0
+                },
+                {
+                    "Direction": "less than",
+                    "Name": "lower non critical",
+                    "Severity": 0,
+                    "Value": 1800
+                },
+                {
+                    "Direction": "greater than",
+                    "Name": "upper critical",
+                    "Severity": 1,
+                    "Value": 36200
+                },
+                {
+                    "Direction": "greater than",
+                    "Name": "upper non critical",
+                    "Severity": 0,
+                    "Value": 28960
+                }
+            ],
+            "Type": "I2CFan"
+        },
+        {
+            "Address": "0x52",
+            "BindConnector": "Fan4 connector",
+            "Bus": 6,
+            "Index": 3,
+            "MaxReading": 14500,
+            "Name": "Fan4a_in",
+            "PowerState": "Always",
+            "Presence": {
+                "MonitorType": "Polling",
+                "PinName": "FAN3_PRESENCE_R_N",
+                "Polarity": "Low"
+            },
+            "Thresholds": [
+                {
+                    "Direction": "less than",
+                    "Name": "lower critical",
+                    "Severity": 1,
+                    "Value": 0
+                },
+                {
+                    "Direction": "less than",
+                    "Name": "lower non critical",
+                    "Severity": 0,
+                    "Value": 1800
+                },
+                {
+                    "Direction": "greater than",
+                    "Name": "upper critical",
+                    "Severity": 1,
+                    "Value": 36200
+                },
+                {
+                    "Direction": "greater than",
+                    "Name": "upper non critical",
+                    "Severity": 0,
+                    "Value": 28960
+                }
+            ],
+            "Type": "I2CFan"
+        },
+        {
+            "Address": "0x52",
+            "BindConnector": "Fan5 connector",
+            "Bus": 6,
+            "Index": 4,
+            "MaxReading": 14500,
+            "Name": "Fan5a_in",
+            "PowerState": "Always",
+            "Presence": {
+                "MonitorType": "Polling",
+                "PinName": "FAN4_PRESENCE_R_N",
+                "Polarity": "Low"
+            },
+            "Thresholds": [
+                {
+                    "Direction": "less than",
+                    "Name": "lower critical",
+                    "Severity": 1,
+                    "Value": 0
+                },
+                {
+                    "Direction": "less than",
+                    "Name": "lower non critical",
+                    "Severity": 0,
+                    "Value": 1800
+                },
+                {
+                    "Direction": "greater than",
+                    "Name": "upper critical",
+                    "Severity": 1,
+                    "Value": 36200
+                },
+                {
+                    "Direction": "greater than",
+                    "Name": "upper non critical",
+                    "Severity": 0,
+                    "Value": 28960
+                }
+            ],
+            "Type": "I2CFan"
+        },
+        {
+            "Address": "0x52",
+            "BindConnector": "Fan1 connector",
+            "Bus": 6,
+            "Index": 5,
             "MaxReading": 14500,
             "Name": "Fan1b_in",
             "PowerState": "Always",
@@ -86,48 +250,7 @@
             "Address": "0x52",
             "BindConnector": "Fan2 connector",
             "Bus": 6,
-            "Index": 2,
-            "MaxReading": 14500,
-            "Name": "Fan2a_in",
-            "PowerState": "Always",
-            "Presence": {
-                "MonitorType": "Polling",
-                "PinName": "FAN1_PRESENCE_R_N",
-                "Polarity": "Low"
-            },
-            "Thresholds": [
-                {
-                    "Direction": "less than",
-                    "Name": "lower critical",
-                    "Severity": 1,
-                    "Value": 0
-                },
-                {
-                    "Direction": "less than",
-                    "Name": "lower non critical",
-                    "Severity": 0,
-                    "Value": 1800
-                },
-                {
-                    "Direction": "greater than",
-                    "Name": "upper critical",
-                    "Severity": 1,
-                    "Value": 36200
-                },
-                {
-                    "Direction": "greater than",
-                    "Name": "upper non critical",
-                    "Severity": 0,
-                    "Value": 28960
-                }
-            ],
-            "Type": "I2CFan"
-        },
-        {
-            "Address": "0x52",
-            "BindConnector": "Fan2 connector",
-            "Bus": 6,
-            "Index": 3,
+            "Index": 6,
             "MaxReading": 14500,
             "Name": "Fan2b_in",
             "PowerState": "Always",
@@ -168,48 +291,7 @@
             "Address": "0x52",
             "BindConnector": "Fan3 connector",
             "Bus": 6,
-            "Index": 4,
-            "MaxReading": 14500,
-            "Name": "Fan3a_in",
-            "PowerState": "Always",
-            "Presence": {
-                "MonitorType": "Polling",
-                "PinName": "FAN2_PRESENCE_R_N",
-                "Polarity": "Low"
-            },
-            "Thresholds": [
-                {
-                    "Direction": "less than",
-                    "Name": "lower critical",
-                    "Severity": 1,
-                    "Value": 0
-                },
-                {
-                    "Direction": "less than",
-                    "Name": "lower non critical",
-                    "Severity": 0,
-                    "Value": 1800
-                },
-                {
-                    "Direction": "greater than",
-                    "Name": "upper critical",
-                    "Severity": 1,
-                    "Value": 36200
-                },
-                {
-                    "Direction": "greater than",
-                    "Name": "upper non critical",
-                    "Severity": 0,
-                    "Value": 28960
-                }
-            ],
-            "Type": "I2CFan"
-        },
-        {
-            "Address": "0x52",
-            "BindConnector": "Fan3 connector",
-            "Bus": 6,
-            "Index": 5,
+            "Index": 7,
             "MaxReading": 14500,
             "Name": "Fan3b_in",
             "PowerState": "Always",
@@ -250,95 +332,13 @@
             "Address": "0x52",
             "BindConnector": "Fan4 connector",
             "Bus": 6,
-            "Index": 6,
-            "MaxReading": 14500,
-            "Name": "Fan4a_in",
-            "PowerState": "Always",
-            "Presence": {
-                "MonitorType": "Polling",
-                "PinName": "FAN3_PRESENCE_R_N",
-                "Polarity": "Low"
-            },
-            "Thresholds": [
-                {
-                    "Direction": "less than",
-                    "Name": "lower critical",
-                    "Severity": 1,
-                    "Value": 0
-                },
-                {
-                    "Direction": "less than",
-                    "Name": "lower non critical",
-                    "Severity": 0,
-                    "Value": 1800
-                },
-                {
-                    "Direction": "greater than",
-                    "Name": "upper critical",
-                    "Severity": 1,
-                    "Value": 36200
-                },
-                {
-                    "Direction": "greater than",
-                    "Name": "upper non critical",
-                    "Severity": 0,
-                    "Value": 28960
-                }
-            ],
-            "Type": "I2CFan"
-        },
-        {
-            "Address": "0x52",
-            "BindConnector": "Fan4 connector",
-            "Bus": 6,
-            "Index": 7,
+            "Index": 8,
             "MaxReading": 14500,
             "Name": "Fan4b_in",
             "PowerState": "Always",
             "Presence": {
                 "MonitorType": "Polling",
                 "PinName": "FAN3_PRESENCE_R_N",
-                "Polarity": "Low"
-            },
-            "Thresholds": [
-                {
-                    "Direction": "less than",
-                    "Name": "lower critical",
-                    "Severity": 1,
-                    "Value": 0
-                },
-                {
-                    "Direction": "less than",
-                    "Name": "lower non critical",
-                    "Severity": 0,
-                    "Value": 1800
-                },
-                {
-                    "Direction": "greater than",
-                    "Name": "upper critical",
-                    "Severity": 1,
-                    "Value": 36200
-                },
-                {
-                    "Direction": "greater than",
-                    "Name": "upper non critical",
-                    "Severity": 0,
-                    "Value": 28960
-                }
-            ],
-            "Type": "I2CFan"
-        },
-        {
-            "Address": "0x52",
-            "BindConnector": "Fan5 connector",
-            "Bus": 6,
-            "Index": 8,
-            "MaxReading": 14500,
-            "Name": "Fan5a_in",
-            "PowerState": "Always",
-            "Presence": {
-                "MonitorType": "Polling",
-                "PinName": "FAN4_PRESENCE_R_N",
                 "Polarity": "Low"
             },
             "Thresholds": [


### PR DESCRIPTION
The dual rotor fans are indexed by 1 rotor for each fan, followed by the second rotor for those fans.

Tested on system1 hw
Before:
    Fan      Rotor     Present    RPM   PWM: %  Target  Zone
    ---     --------   -------   -----  ------  ------  ----
    Fan1    Fan1a_in    true      4102   39.22   100%   0 (CECIO)
    Fan1    Fan1b_in    true      4054
    Fan2    Fan2a_in    true      4032   39.22   100%   0 (CECIO)
    Fan2    Fan2b_in    true      4089
    Fan3    Fan3a_in    true      4040   39.22   100%   0 (CECIO)
    Fan3    Fan3b_in    true         0
    Fan4    Fan4a_in    true         0   39.22   100%   0 (CECIO)
    Fan4    Fan4b_in    true         0
    Fan5    Fan5a_in    true         0   39.22   100%   0 (CECIO)
    Fan5    Fan5b_in    true         0
    Fan6    Fan6_in     false        0   39.22   100%   1 (NVME)
    Fan7    Fan7_in     false        0   39.22   100%   1 (NVME)

After: Fan      Rotor     Present    RPM   PWM: %  Target  Zone
    ---     --------   -------   -----  ------  ------  ----
    Fan1    Fan1a_in    true      3972   39.22   100%   0 (CECIO)
    Fan1    Fan1b_in    true         0
    Fan2    Fan2a_in    true      4002   39.22   100%   0 (CECIO)
    Fan2    Fan2b_in    true         0
    Fan3    Fan3a_in    true      4054   39.22   100%   0 (CECIO)
    Fan3    Fan3b_in    true         0
    Fan4    Fan4a_in    true      4027   39.22   100%   0 (CECIO)
    Fan4    Fan4b_in    true         0
    Fan5    Fan5a_in    true      4054   39.22   100%   0 (CECIO)
    Fan5    Fan5b_in    true         0
    Fan6    Fan6_in     false        0   39.22   100%   1 (NVME)
    Fan7    Fan7_in     false        0   39.22   100%   1 (NVME)
Change-Id: Iee747f9b22099719f5d90296c5154b047b74880c