### PR TITLE
configurations: system1: add XeonCPU

### DIFF
--- a/configurations/system1_baseboard.json
+++ b/configurations/system1_baseboard.json
@@ -474,6 +474,20 @@
             "Name": "PCIE_SWITCH2_TEMP",
             "Name1": "PCIE_SWITCH6_TEMP",
             "Type": "TMP432"
+        },
+        {
+            "Address": "0x30",
+            "Bus": 0,
+            "CpuID": 0,
+            "Name": "CPU 0",
+            "Type": "XeonCPU"
+        },
+        {
+            "Address": "0x31",
+            "Bus": 0,
+            "CpuID": 1,
+            "Name": "CPU 1",
+            "Type": "XeonCPU"
         }
     ],
     "Name": "IBM System1 Baseboard",


### PR DESCRIPTION
Adding these in allows the CPU and DIMM temperatures to be collected on the BMC.

Tested:
- Confirmed we now get DIMM and Core temperatures on system1

Change-Id: Ia0578a60463b44bebbeaf74fa67f275a493bfacb