### PR TITLE
configurations: system1: change PSUs to CRPS

### DIFF
--- a/configurations/system1_baseboard.json
+++ b/configurations/system1_baseboard.json
@@ -352,34 +352,6 @@
             "Type": "ADC"
         },
         {
-            "I2CAddress": 88,
-            "I2CBus": 2,
-            "Name": "Power Supply Slot 0",
-            "NamedPresenceGpio": "presence-ps0",
-            "Type": "IBMCFFPSConnector"
-        },
-        {
-            "I2CAddress": 89,
-            "I2CBus": 2,
-            "Name": "Power Supply Slot 1",
-            "NamedPresenceGpio": "presence-ps1",
-            "Type": "IBMCFFPSConnector"
-        },
-        {
-            "I2CAddress": 90,
-            "I2CBus": 2,
-            "Name": "Power Supply Slot 2",
-            "NamedPresenceGpio": "presence-ps2",
-            "Type": "IBMCFFPSConnector"
-        },
-        {
-            "I2CAddress": 91,
-            "I2CBus": 2,
-            "Name": "Power Supply Slot 3",
-            "NamedPresenceGpio": "presence-ps3",
-            "Type": "IBMCFFPSConnector"
-        },
-        {
             "Name": "Fan1 connector",
             "Pwm": 0,
             "PwmName": "Fan1_Pwm",

--- a/configurations/system1_psu.json
+++ b/configurations/system1_psu.json
@@ -1,0 +1,138 @@
+[
+    {
+        "Exposes": [
+            {
+                "Address": "0x58",
+                "Bus": "2",
+                "Labels": [
+                    "iin",
+                    "iout1",
+                    "vin",
+                    "vout1",
+                    "pin"
+                ],
+                "Name": "PSU0",
+                "Name1": "BCM0",
+                "PollRate": 5.0,
+                "PowerState": "Always",
+                "Type": "CRPS185"
+            }
+        ],
+        "Name": "Intel CRPS185 2400W 1",
+        "Probe": "FOUND('IBM System1 Baseboard')",
+        "ProductId": 1,
+        "Type": "PowerSupply",
+        "xyz.openbmc_project.Inventory.Decorator.Asset": {
+            "Manufacturer": "Intel",
+            "Model": "CRPS185",
+            "PartNumber": "CRPS185TD1E1368T01",
+            "SerialNumber": ""
+        },
+        "xyz.openbmc_project.Inventory.Decorator.Replaceable": {
+            "FieldReplaceable": false,
+            "HotPluggable": false
+        }
+    },
+    {
+        "Exposes": [
+            {
+                "Address": "0x59",
+                "Bus": "2",
+                "Labels": [
+                    "iin",
+                    "iout1",
+                    "vin",
+                    "vout1",
+                    "pin"
+                ],
+                "Name": "PSU1",
+                "Name1": "BCM1",
+                "PollRate": 5.0,
+                "PowerState": "Always",
+                "Type": "CRPS185"
+            }
+        ],
+        "Name": "Intel CRPS185 2400W 2",
+        "Probe": "FOUND('IBM System1 Baseboard')",
+        "ProductId": 2,
+        "Type": "PowerSupply",
+        "xyz.openbmc_project.Inventory.Decorator.Asset": {
+            "Manufacturer": "Intel",
+            "Model": "CRPS185",
+            "PartNumber": "CRPS185TD1E1368T01",
+            "SerialNumber": ""
+        },
+        "xyz.openbmc_project.Inventory.Decorator.Replaceable": {
+            "FieldReplaceable": false,
+            "HotPluggable": false
+        }
+    },
+    {
+        "Exposes": [
+            {
+                "Address": "0x5a",
+                "Bus": "2",
+                "Labels": [
+                    "iin",
+                    "iout1",
+                    "vin",
+                    "vout1",
+                    "pin"
+                ],
+                "Name": "PSU2",
+                "Name1": "BCM2",
+                "PollRate": 5.0,
+                "PowerState": "Always",
+                "Type": "CRPS185"
+            }
+        ],
+        "Name": "Intel CRPS185 2400W 3",
+        "Probe": "FOUND('IBM System1 Baseboard')",
+        "ProductId": 3,
+        "Type": "PowerSupply",
+        "xyz.openbmc_project.Inventory.Decorator.Asset": {
+            "Manufacturer": "Intel",
+            "Model": "CRPS185",
+            "PartNumber": "CRPS185TD1E1368T01",
+            "SerialNumber": ""
+        },
+        "xyz.openbmc_project.Inventory.Decorator.Replaceable": {
+            "FieldReplaceable": false,
+            "HotPluggable": false
+        }
+    },
+    {
+        "Exposes": [
+            {
+                "Address": "0x5b",
+                "Bus": "2",
+                "Labels": [
+                    "iin",
+                    "iout1",
+                    "vin",
+                    "vout1",
+                    "pin"
+                ],
+                "Name": "PSU3",
+                "Name1": "BCM3",
+                "PollRate": 5.0,
+                "PowerState": "Always",
+                "Type": "CRPS185"
+            }
+        ],
+        "Name": "Intel CRPS185 2400W 4",
+        "Probe": "FOUND('IBM System1 Baseboard')",
+        "ProductId": 4,
+        "Type": "PowerSupply",
+        "xyz.openbmc_project.Inventory.Decorator.Asset": {
+            "Manufacturer": "Intel",
+            "Model": "CRPS185",
+            "PartNumber": "CRPS185TD1E1368T01",
+            "SerialNumber": ""
+        },
+        "xyz.openbmc_project.Inventory.Decorator.Replaceable": {
+            "FieldReplaceable": false,
+            "HotPluggable": false
+        }
+    }
+]

--- a/meson.build
+++ b/meson.build
@@ -187,6 +187,7 @@ configs = [
     'supermicro-pws-920p-sq_psu.json',
     'system1_baseboard.json',
     'system1_chassis.json',
+    'system1_psu.json',
     'terminus_2x100g_nic_tsff.json',
     'tola.json',
     'twinlake.json',


### PR DESCRIPTION
System1 ended up going with standard Common Redundant Power Supplies (CRPS). Add them in and create sensors for what's available.

Testing:
- Verified expected sensors were in GUI and values seemed reasonable at power off and on states

Change-Id: I1b265597ee765a79558cff05a284263fc4334738

Upstream: https://gerrit.openbmc.org/c/openbmc/entity-manager/+/75912