### PR TITLE
configurations: system1: update downstream system1_chassis.json

### DIFF
--- a/configurations/system1_baseboard.json
+++ b/configurations/system1_baseboard.json
@@ -516,192 +516,224 @@
             "Address": "0x4b",
             "Bus": 72,
             "Name": "SPYRE9_TEMP1",
+            "PowerState": "On",
             "Type": "TMP112"
         },
         {
             "Address": "0x48",
             "Bus": 73,
             "Name": "SPYRE9_TEMP2",
+            "PowerState": "On",
             "Type": "TMP112"
         },
         {
             "Address": "0x4b",
             "Bus": 74,
             "Name": "SPYRE10_TEMP1",
+            "PowerState": "On",
             "Type": "TMP112"
         },
         {
             "Address": "0x48",
             "Bus": 75,
             "Name": "SPYRE10_TEMP2",
+            "PowerState": "On",
             "Type": "TMP112"
         },
         {
             "Address": "0x4b",
             "Bus": 76,
             "Name": "SPYRE11_TEMP1",
+            "PowerState": "On",
             "Type": "TMP112"
         },
         {
             "Address": "0x48",
             "Bus": 77,
             "Name": "SPYRE11_TEMP2",
+            "PowerState": "On",
             "Type": "TMP112"
         },
         {
             "Address": "0x4b",
             "Bus": 78,
             "Name": "SPYRE12_TEMP1",
+            "PowerState": "On",
             "Type": "TMP112"
         },
         {
             "Address": "0x48",
             "Bus": 79,
             "Name": "SPYRE12_TEMP2",
+            "PowerState": "On",
             "Type": "TMP112"
         },
         {
             "Address": "0x4b",
             "Bus": 80,
             "Name": "SPYRE13_TEMP1",
+            "PowerState": "On",
             "Type": "TMP112"
         },
         {
             "Address": "0x48",
             "Bus": 81,
             "Name": "SPYRE13_TEMP2",
+            "PowerState": "On",
             "Type": "TMP112"
         },
         {
             "Address": "0x4b",
             "Bus": 82,
             "Name": "SPYRE14_TEMP1",
+            "PowerState": "On",
             "Type": "TMP112"
         },
         {
             "Address": "0x48",
             "Bus": 83,
             "Name": "SPYRE14_TEMP2",
+            "PowerState": "On",
             "Type": "TMP112"
         },
         {
             "Address": "0x4b",
             "Bus": 84,
             "Name": "SPYRE15_TEMP1",
+            "PowerState": "On",
             "Type": "TMP112"
         },
         {
             "Address": "0x48",
             "Bus": 85,
             "Name": "SPYRE15_TEMP2",
+            "PowerState": "On",
             "Type": "TMP112"
         },
         {
             "Address": "0x4b",
             "Bus": 86,
             "Name": "SPYRE16_TEMP1",
+            "PowerState": "On",
             "Type": "TMP112"
         },
         {
             "Address": "0x48",
             "Bus": 87,
             "Name": "SPYRE16_TEMP2",
+            "PowerState": "On",
             "Type": "TMP112"
         },
         {
             "Address": "0x4b",
             "Bus": 88,
             "Name": "SPYRE1_TEMP1",
+            "PowerState": "On",
             "Type": "TMP112"
         },
         {
             "Address": "0x48",
             "Bus": 89,
             "Name": "SPYRE1_TEMP2",
+            "PowerState": "On",
             "Type": "TMP112"
         },
         {
             "Address": "0x4b",
             "Bus": 90,
             "Name": "SPYRE2_TEMP1",
+            "PowerState": "On",
             "Type": "TMP112"
         },
         {
             "Address": "0x48",
             "Bus": 91,
             "Name": "SPYRE2_TEMP2",
+            "PowerState": "On",
             "Type": "TMP112"
         },
         {
             "Address": "0x4b",
             "Bus": 92,
             "Name": "SPYRE3_TEMP1",
+            "PowerState": "On",
             "Type": "TMP112"
         },
         {
             "Address": "0x48",
             "Bus": 93,
             "Name": "SPYRE3_TEMP2",
+            "PowerState": "On",
             "Type": "TMP112"
         },
         {
             "Address": "0x4b",
             "Bus": 94,
             "Name": "SPYRE4_TEMP1",
+            "PowerState": "On",
             "Type": "TMP112"
         },
         {
             "Address": "0x48",
             "Bus": 95,
             "Name": "SPYRE4_TEMP2",
+            "PowerState": "On",
             "Type": "TMP112"
         },
         {
             "Address": "0x4b",
             "Bus": 96,
             "Name": "SPYRE5_TEMP1",
+            "PowerState": "On",
             "Type": "TMP112"
         },
         {
             "Address": "0x48",
             "Bus": 97,
             "Name": "SPYRE5_TEMP2",
+            "PowerState": "On",
             "Type": "TMP112"
         },
         {
             "Address": "0x4b",
             "Bus": 98,
             "Name": "SPYRE6_TEMP1",
+            "PowerState": "On",
             "Type": "TMP112"
         },
         {
             "Address": "0x48",
             "Bus": 99,
             "Name": "SPYRE6_TEMP2",
+            "PowerState": "On",
             "Type": "TMP112"
         },
         {
             "Address": "0x4b",
             "Bus": 100,
             "Name": "SPYRE7_TEMP1",
+            "PowerState": "On",
             "Type": "TMP112"
         },
         {
             "Address": "0x48",
             "Bus": 101,
             "Name": "SPYRE7_TEMP2",
+            "PowerState": "On",
             "Type": "TMP112"
         },
         {
             "Address": "0x4b",
             "Bus": 102,
             "Name": "SPYRE8_TEMP1",
+            "PowerState": "On",
             "Type": "TMP112"
         },
         {
             "Address": "0x48",
-            "Bus": 102,
+            "Bus": 103,
             "Name": "SPYRE8_TEMP2",
+            "PowerState": "On",
             "Type": "TMP112"
         },
         {
@@ -709,6 +741,7 @@
             "Bus": 70,
             "Name": "PCIE_SWITCH1_TEMP",
             "Name1": "PCIE_SWITCH3_TEMP",
+            "PowerState": "On",
             "Type": "TMP432"
         },
         {
@@ -716,6 +749,7 @@
             "Bus": 71,
             "Name": "PCIE_SWITCH4_TEMP",
             "Name1": "PCIE_SWITCH5_TEMP",
+            "PowerState": "On",
             "Type": "TMP432"
         },
         {
@@ -723,6 +757,7 @@
             "Bus": 54,
             "Name": "PCIE_SWITCH2_TEMP",
             "Name1": "PCIE_SWITCH6_TEMP",
+            "PowerState": "On",
             "Type": "TMP432"
         },
         {

--- a/configurations/system1_chassis.json
+++ b/configurations/system1_chassis.json
@@ -7,7 +7,7 @@
             "Index": 0,
             "MaxReading": 14500,
             "Name": "Fan1a_in",
-            "PowerState": "Always",
+            "PowerState": "On",
             "Presence": {
                 "MonitorType": "Polling",
                 "PinName": "FAN0_PRESENCE_R_N",
@@ -24,7 +24,7 @@
                     "Direction": "less than",
                     "Name": "lower non critical",
                     "Severity": 0,
-                    "Value": 1800
+                    "Value": 4000
                 },
                 {
                     "Direction": "greater than",
@@ -36,171 +36,7 @@
                     "Direction": "greater than",
                     "Name": "upper non critical",
                     "Severity": 0,
-                    "Value": 28960
-                }
-            ],
-            "Type": "I2CFan"
-        },
-        {
-            "Address": "0x52",
-            "BindConnector": "Fan2 connector",
-            "Bus": 6,
-            "Index": 1,
-            "MaxReading": 14500,
-            "Name": "Fan2a_in",
-            "PowerState": "Always",
-            "Presence": {
-                "MonitorType": "Polling",
-                "PinName": "FAN1_PRESENCE_R_N",
-                "Polarity": "Low"
-            },
-            "Thresholds": [
-                {
-                    "Direction": "less than",
-                    "Name": "lower critical",
-                    "Severity": 1,
-                    "Value": 0
-                },
-                {
-                    "Direction": "less than",
-                    "Name": "lower non critical",
-                    "Severity": 0,
-                    "Value": 1800
-                },
-                {
-                    "Direction": "greater than",
-                    "Name": "upper critical",
-                    "Severity": 1,
-                    "Value": 36200
-                },
-                {
-                    "Direction": "greater than",
-                    "Name": "upper non critical",
-                    "Severity": 0,
-                    "Value": 28960
-                }
-            ],
-            "Type": "I2CFan"
-        },
-        {
-            "Address": "0x52",
-            "BindConnector": "Fan3 connector",
-            "Bus": 6,
-            "Index": 2,
-            "MaxReading": 14500,
-            "Name": "Fan3a_in",
-            "PowerState": "Always",
-            "Presence": {
-                "MonitorType": "Polling",
-                "PinName": "FAN2_PRESENCE_R_N",
-                "Polarity": "Low"
-            },
-            "Thresholds": [
-                {
-                    "Direction": "less than",
-                    "Name": "lower critical",
-                    "Severity": 1,
-                    "Value": 0
-                },
-                {
-                    "Direction": "less than",
-                    "Name": "lower non critical",
-                    "Severity": 0,
-                    "Value": 1800
-                },
-                {
-                    "Direction": "greater than",
-                    "Name": "upper critical",
-                    "Severity": 1,
-                    "Value": 36200
-                },
-                {
-                    "Direction": "greater than",
-                    "Name": "upper non critical",
-                    "Severity": 0,
-                    "Value": 28960
-                }
-            ],
-            "Type": "I2CFan"
-        },
-        {
-            "Address": "0x52",
-            "BindConnector": "Fan4 connector",
-            "Bus": 6,
-            "Index": 3,
-            "MaxReading": 14500,
-            "Name": "Fan4a_in",
-            "PowerState": "Always",
-            "Presence": {
-                "MonitorType": "Polling",
-                "PinName": "FAN3_PRESENCE_R_N",
-                "Polarity": "Low"
-            },
-            "Thresholds": [
-                {
-                    "Direction": "less than",
-                    "Name": "lower critical",
-                    "Severity": 1,
-                    "Value": 0
-                },
-                {
-                    "Direction": "less than",
-                    "Name": "lower non critical",
-                    "Severity": 0,
-                    "Value": 1800
-                },
-                {
-                    "Direction": "greater than",
-                    "Name": "upper critical",
-                    "Severity": 1,
-                    "Value": 36200
-                },
-                {
-                    "Direction": "greater than",
-                    "Name": "upper non critical",
-                    "Severity": 0,
-                    "Value": 28960
-                }
-            ],
-            "Type": "I2CFan"
-        },
-        {
-            "Address": "0x52",
-            "BindConnector": "Fan5 connector",
-            "Bus": 6,
-            "Index": 4,
-            "MaxReading": 14500,
-            "Name": "Fan5a_in",
-            "PowerState": "Always",
-            "Presence": {
-                "MonitorType": "Polling",
-                "PinName": "FAN4_PRESENCE_R_N",
-                "Polarity": "Low"
-            },
-            "Thresholds": [
-                {
-                    "Direction": "less than",
-                    "Name": "lower critical",
-                    "Severity": 1,
-                    "Value": 0
-                },
-                {
-                    "Direction": "less than",
-                    "Name": "lower non critical",
-                    "Severity": 0,
-                    "Value": 1800
-                },
-                {
-                    "Direction": "greater than",
-                    "Name": "upper critical",
-                    "Severity": 1,
-                    "Value": 36200
-                },
-                {
-                    "Direction": "greater than",
-                    "Name": "upper non critical",
-                    "Severity": 0,
-                    "Value": 28960
+                    "Value": 15000
                 }
             ],
             "Type": "I2CFan"
@@ -212,7 +48,7 @@
             "Index": 5,
             "MaxReading": 14500,
             "Name": "Fan1b_in",
-            "PowerState": "Always",
+            "PowerState": "On",
             "Presence": {
                 "MonitorType": "Polling",
                 "PinName": "FAN0_PRESENCE_R_N",
@@ -229,7 +65,7 @@
                     "Direction": "less than",
                     "Name": "lower non critical",
                     "Severity": 0,
-                    "Value": 1800
+                    "Value": 4000
                 },
                 {
                     "Direction": "greater than",
@@ -241,7 +77,7 @@
                     "Direction": "greater than",
                     "Name": "upper non critical",
                     "Severity": 0,
-                    "Value": 28960
+                    "Value": 15000
                 }
             ],
             "Type": "I2CFan"
@@ -250,10 +86,10 @@
             "Address": "0x52",
             "BindConnector": "Fan2 connector",
             "Bus": 6,
-            "Index": 6,
+            "Index": 1,
             "MaxReading": 14500,
-            "Name": "Fan2b_in",
-            "PowerState": "Always",
+            "Name": "Fan2a_in",
+            "PowerState": "On",
             "Presence": {
                 "MonitorType": "Polling",
                 "PinName": "FAN1_PRESENCE_R_N",
@@ -270,7 +106,7 @@
                     "Direction": "less than",
                     "Name": "lower non critical",
                     "Severity": 0,
-                    "Value": 1800
+                    "Value": 4000
                 },
                 {
                     "Direction": "greater than",
@@ -282,7 +118,48 @@
                     "Direction": "greater than",
                     "Name": "upper non critical",
                     "Severity": 0,
-                    "Value": 28960
+                    "Value": 15000
+                }
+            ],
+            "Type": "I2CFan"
+        },
+        {
+            "Address": "0x52",
+            "BindConnector": "Fan2 connector",
+            "Bus": 6,
+            "Index": 6,
+            "MaxReading": 14500,
+            "Name": "Fan2b_in",
+            "PowerState": "On",
+            "Presence": {
+                "MonitorType": "Polling",
+                "PinName": "FAN1_PRESENCE_R_N",
+                "Polarity": "Low"
+            },
+            "Thresholds": [
+                {
+                    "Direction": "less than",
+                    "Name": "lower critical",
+                    "Severity": 1,
+                    "Value": 0
+                },
+                {
+                    "Direction": "less than",
+                    "Name": "lower non critical",
+                    "Severity": 0,
+                    "Value": 4000
+                },
+                {
+                    "Direction": "greater than",
+                    "Name": "upper critical",
+                    "Severity": 1,
+                    "Value": 36200
+                },
+                {
+                    "Direction": "greater than",
+                    "Name": "upper non critical",
+                    "Severity": 0,
+                    "Value": 15000
                 }
             ],
             "Type": "I2CFan"
@@ -291,10 +168,10 @@
             "Address": "0x52",
             "BindConnector": "Fan3 connector",
             "Bus": 6,
-            "Index": 7,
+            "Index": 2,
             "MaxReading": 14500,
-            "Name": "Fan3b_in",
-            "PowerState": "Always",
+            "Name": "Fan3a_in",
+            "PowerState": "On",
             "Presence": {
                 "MonitorType": "Polling",
                 "PinName": "FAN2_PRESENCE_R_N",
@@ -311,7 +188,7 @@
                     "Direction": "less than",
                     "Name": "lower non critical",
                     "Severity": 0,
-                    "Value": 1800
+                    "Value": 4000
                 },
                 {
                     "Direction": "greater than",
@@ -323,7 +200,48 @@
                     "Direction": "greater than",
                     "Name": "upper non critical",
                     "Severity": 0,
-                    "Value": 28960
+                    "Value": 15000
+                }
+            ],
+            "Type": "I2CFan"
+        },
+        {
+            "Address": "0x52",
+            "BindConnector": "Fan3 connector",
+            "Bus": 6,
+            "Index": 7,
+            "MaxReading": 14500,
+            "Name": "Fan3b_in",
+            "PowerState": "On",
+            "Presence": {
+                "MonitorType": "Polling",
+                "PinName": "FAN2_PRESENCE_R_N",
+                "Polarity": "Low"
+            },
+            "Thresholds": [
+                {
+                    "Direction": "less than",
+                    "Name": "lower critical",
+                    "Severity": 1,
+                    "Value": 0
+                },
+                {
+                    "Direction": "less than",
+                    "Name": "lower non critical",
+                    "Severity": 0,
+                    "Value": 4000
+                },
+                {
+                    "Direction": "greater than",
+                    "Name": "upper critical",
+                    "Severity": 1,
+                    "Value": 36200
+                },
+                {
+                    "Direction": "greater than",
+                    "Name": "upper non critical",
+                    "Severity": 0,
+                    "Value": 15000
                 }
             ],
             "Type": "I2CFan"
@@ -332,10 +250,10 @@
             "Address": "0x52",
             "BindConnector": "Fan4 connector",
             "Bus": 6,
-            "Index": 8,
+            "Index": 3,
             "MaxReading": 14500,
-            "Name": "Fan4b_in",
-            "PowerState": "Always",
+            "Name": "Fan4a_in",
+            "PowerState": "On",
             "Presence": {
                 "MonitorType": "Polling",
                 "PinName": "FAN3_PRESENCE_R_N",
@@ -352,7 +270,7 @@
                     "Direction": "less than",
                     "Name": "lower non critical",
                     "Severity": 0,
-                    "Value": 1800
+                    "Value": 4000
                 },
                 {
                     "Direction": "greater than",
@@ -364,7 +282,48 @@
                     "Direction": "greater than",
                     "Name": "upper non critical",
                     "Severity": 0,
-                    "Value": 28960
+                    "Value": 15000
+                }
+            ],
+            "Type": "I2CFan"
+        },
+        {
+            "Address": "0x52",
+            "BindConnector": "Fan4 connector",
+            "Bus": 6,
+            "Index": 8,
+            "MaxReading": 14500,
+            "Name": "Fan4b_in",
+            "PowerState": "On",
+            "Presence": {
+                "MonitorType": "Polling",
+                "PinName": "FAN3_PRESENCE_R_N",
+                "Polarity": "Low"
+            },
+            "Thresholds": [
+                {
+                    "Direction": "less than",
+                    "Name": "lower critical",
+                    "Severity": 1,
+                    "Value": 0
+                },
+                {
+                    "Direction": "less than",
+                    "Name": "lower non critical",
+                    "Severity": 0,
+                    "Value": 4000
+                },
+                {
+                    "Direction": "greater than",
+                    "Name": "upper critical",
+                    "Severity": 1,
+                    "Value": 36200
+                },
+                {
+                    "Direction": "greater than",
+                    "Name": "upper non critical",
+                    "Severity": 0,
+                    "Value": 15000
                 }
             ],
             "Type": "I2CFan"
@@ -373,10 +332,10 @@
             "Address": "0x52",
             "BindConnector": "Fan5 connector",
             "Bus": 6,
-            "Index": 9,
+            "Index": 4,
             "MaxReading": 14500,
-            "Name": "Fan5b_in",
-            "PowerState": "Always",
+            "Name": "Fan5a_in",
+            "PowerState": "On",
             "Presence": {
                 "MonitorType": "Polling",
                 "PinName": "FAN4_PRESENCE_R_N",
@@ -393,7 +352,7 @@
                     "Direction": "less than",
                     "Name": "lower non critical",
                     "Severity": 0,
-                    "Value": 1800
+                    "Value": 4000
                 },
                 {
                     "Direction": "greater than",
@@ -405,7 +364,48 @@
                     "Direction": "greater than",
                     "Name": "upper non critical",
                     "Severity": 0,
-                    "Value": 28960
+                    "Value": 15000
+                }
+            ],
+            "Type": "I2CFan"
+        },
+        {
+            "Address": "0x52",
+            "BindConnector": "Fan5 connector",
+            "Bus": 6,
+            "Index": 9,
+            "MaxReading": 14500,
+            "Name": "Fan5b_in",
+            "PowerState": "On",
+            "Presence": {
+                "MonitorType": "Polling",
+                "PinName": "FAN4_PRESENCE_R_N",
+                "Polarity": "Low"
+            },
+            "Thresholds": [
+                {
+                    "Direction": "less than",
+                    "Name": "lower critical",
+                    "Severity": 1,
+                    "Value": 0
+                },
+                {
+                    "Direction": "less than",
+                    "Name": "lower non critical",
+                    "Severity": 0,
+                    "Value": 4000
+                },
+                {
+                    "Direction": "greater than",
+                    "Name": "upper critical",
+                    "Severity": 1,
+                    "Value": 36200
+                },
+                {
+                    "Direction": "greater than",
+                    "Name": "upper non critical",
+                    "Severity": 0,
+                    "Value": 15000
                 }
             ],
             "Type": "I2CFan"
@@ -417,7 +417,7 @@
             "Index": 0,
             "MaxReading": 25000,
             "Name": "Fan6_in",
-            "PowerState": "Always",
+            "PowerState": "On",
             "Presence": {
                 "MonitorType": "Polling",
                 "PinName": "FAN5_PRESENCE_N",
@@ -446,7 +446,7 @@
                     "Direction": "greater than",
                     "Name": "upper non critical",
                     "Severity": 0,
-                    "Value": 28960
+                    "Value": 27000
                 }
             ],
             "Type": "I2CFan"
@@ -458,7 +458,7 @@
             "Index": 1,
             "MaxReading": 25000,
             "Name": "Fan7_in",
-            "PowerState": "Always",
+            "PowerState": "On",
             "Presence": {
                 "MonitorType": "Polling",
                 "PinName": "FAN6_PRESENCE_N",
@@ -487,7 +487,7 @@
                     "Direction": "greater than",
                     "Name": "upper non critical",
                     "Severity": 0,
-                    "Value": 28960
+                    "Value": 27000
                 }
             ],
             "Type": "I2CFan"
@@ -730,36 +730,6 @@
             "NegativeHysteresis": 0,
             "OutLimitMax": 100,
             "OutLimitMin": 20,
-            "Outputs": [],
-            "PCoefficient": -500,
-            "PositiveHysteresis": 0,
-            "SetPoint": 85,
-            "SlewNeg": 0,
-            "SlewPos": 0,
-            "Type": "Pid",
-            "Zones": [
-                "CECIO"
-            ]
-        },
-        {
-            "Class": "temp",
-            "FFGainCoefficient": 0,
-            "FFOffCoefficient": 0,
-            "ICoefficient": -5,
-            "ILimitMax": 18000,
-            "ILimitMin": 2500,
-            "Inputs": [
-                "PCIE_SWITCH1_TEMP",
-                "PCIE_SWITCH2_TEMP",
-                "PCIE_SWITCH3_TEMP",
-                "PCIE_SWITCH4_TEMP",
-                "PCIE_SWITCH5_TEMP",
-                "PCIE_SWITCH6_TEMP"
-            ],
-            "Name": "PCIE Switch Temperature",
-            "NegativeHysteresis": 0,
-            "OutLimitMax": 18000,
-            "OutLimitMin": 2500,
             "Outputs": [],
             "PCoefficient": -500,
             "PositiveHysteresis": 0,


### PR DESCRIPTION
This is the upstream version of system1_chassis.json, some of the changes were missing downstream.

Updated the system1_baseboard.json:
Modified the PowerState for the PCIE Switches and SPYRE card
thermal sensors to only be read after the host power on.

Corrected one bus number for Spyre card.

Tested on system1 hw

Change-Id: I9fe0d0c9f8f2ba615e1f1e6dbe55cb31468f3f7f