### PR TITLE
fru-device: no scans on power on

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -34,6 +34,12 @@ if get_option('fru-device')
     i2c = cpp.find_library('i2c')
 endif
 
+conf = configuration_data()
+conf.set10(
+    'RESCAN_ON_POWERON',
+    get_option('rescan-on-poweron'),
+)
+
 nlohmann_json_dep = dependency('nlohmann_json', include_type: 'system')
 sdbusplus = dependency('sdbusplus', include_type: 'system')
 phosphor_logging_dep = dependency('phosphor-logging')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -10,3 +10,6 @@ option(
 option(
     'validate-json', type: 'boolean', value: true, description: 'Run JSON schema validation during the build.',
 )
+option(
+    'rescan-on-poweron', type: 'boolean', value: false, description: 'Enable i2c rescans on power on.',
+)


### PR DESCRIPTION
Our systems have lots of i2c buses and muxes. Scanning all of them is problematic, especially during power on when other applications are going out to the i2c buses (including the host firmware).

The only i2c reads we need from fru-device are during the boot to BMC Ready so disable all other i2c reads after that via a new config option.

Tested:
- Confirmed I see the new log in the journal and no i2c bus busy errors with this change during power on