### PR TITLE
configurations: system1: Correct PCI switch thermal sensors

### DIFF
--- a/configurations/system1_baseboard.json
+++ b/configurations/system1_baseboard.json
@@ -739,24 +739,24 @@
         {
             "Address": "0x4c",
             "Bus": 70,
-            "Name": "PCIE_SWITCH1_TEMP",
-            "Name1": "PCIE_SWITCH3_TEMP",
+            "Name": "PCIE_SWITCH3_TEMP",
+            "Name1": "PCIE_SWITCH1_TEMP",
             "PowerState": "On",
             "Type": "TMP432"
         },
         {
             "Address": "0x4c",
             "Bus": 71,
-            "Name": "PCIE_SWITCH4_TEMP",
-            "Name1": "PCIE_SWITCH5_TEMP",
+            "Name": "PCIE_SWITCH5_TEMP",
+            "Name1": "PCIE_SWITCH4_TEMP",
             "PowerState": "On",
             "Type": "TMP432"
         },
         {
             "Address": "0x4c",
             "Bus": 54,
-            "Name": "PCIE_SWITCH2_TEMP",
-            "Name1": "PCIE_SWITCH6_TEMP",
+            "Name": "PCIE_SWITCH6_TEMP",
+            "Name1": "PCIE_SWITCH2_TEMP",
             "PowerState": "On",
             "Type": "TMP432"
         },


### PR DESCRIPTION
The sensor numbering was backwards.

Testing on system1 hw.

Before:
    PCIE_SWITCH1_TEMP     32.69   DegreesC
    PCIE_SWITCH2_TEMP     31.81   DegreesC
    PCIE_SWITCH3_TEMP     40.81   DegreesC
    PCIE_SWITCH4_TEMP     36.75   DegreesC
    PCIE_SWITCH5_TEMP     46.19   DegreesC
    PCIE_SWITCH6_TEMP     40.56   DegreesC

After:
    PCIE_SWITCH1_TEMP     40.56   DegreesC
    PCIE_SWITCH2_TEMP     40.62   DegreesC
    PCIE_SWITCH3_TEMP     32.75   DegreesC
    PCIE_SWITCH4_TEMP     46.06   DegreesC
    PCIE_SWITCH5_TEMP     36.81   DegreesC
    PCIE_SWITCH6_TEMP     31.88   DegreesC

Change-Id: Iaedcbfde951f9a22afd10bde97c4a3c6a90c5740