### PR TITLE
config: Add Balcones and Waterloo

### DIFF
--- a/configurations/balcones.json
+++ b/configurations/balcones.json
@@ -1,0 +1,44 @@
+{
+    "Exposes": [
+        {
+            "Name": "Compatible System",
+            "Names": [
+                "ibm,balcones",
+                "ibm,bonnell"
+            ],
+            "Type": "IBMCompatibleSystem"
+        },
+        {
+            "EnterUtilizationDwellTime": 240,
+            "EnterUtilizationPercent": 8,
+            "ExitUtilizationDwellTime": 10,
+            "ExitUtilizationPercent": 12,
+            "IdlePowerSaverEnabled": true,
+            "Name": "Default Power Mode Properties",
+            "PowerMode": "MaximumPerformance",
+            "Type": "PowerModeProperties"
+        },
+        {
+            "InputVoltage": [
+                110,
+                220
+            ],
+            "Name": "800W IBMCFFPS Configuration",
+            "RedundantCount": 2,
+            "SupportedModel": "51FA",
+            "SupportedType": "PowerSupply",
+            "Type": "SupportedConfiguration"
+        }
+    ],
+    "Name": "Balcones Chassis",
+    "Probe": [
+        "com.ibm.ipzvpd.VSBP({'IM': [96, 0, 64, 0]})"
+    ],
+    "Type": "Chassis",
+    "xyz.openbmc_project.Inventory.Decorator.Compatible": {
+        "Names": [
+            "com.ibm.Hardware.Chassis.Model.Balcones",
+            "com.ibm.Hardware.Chassis.Model.Bonnell"
+        ]
+    }
+}

--- a/configurations/meson.build
+++ b/configurations/meson.build
@@ -24,6 +24,7 @@ configs = [
     'asrock_spc621d8hm3.json',
     'axx1p100hssi_aic.json',
     'axx2prthdhd.json',
+    'balcones.json',
     'bear_lake.json',
     'bear_river.json',
     'bellavista.json',
@@ -194,5 +195,6 @@ configs = [
     'vegman_n110_baseboard.json',
     'vegman_rx20_baseboard.json',
     'vegman_sx20_baseboard.json',
+    'waterloo.json',
     'wft_baseboard.json',
 ]

--- a/configurations/waterloo.json
+++ b/configurations/waterloo.json
@@ -1,0 +1,50 @@
+{
+    "Exposes": [
+        {
+            "BridgeGpio": [
+                {
+                    "Name": "rtc-battery-voltage-read-enable",
+                    "Polarity": "High"
+                }
+            ],
+            "Index": 0,
+            "Name": "Battery Voltage",
+            "PollRate": 86400,
+            "ScaleFactor": 0.4348,
+            "Thresholds": [
+                {
+                    "Direction": "less than",
+                    "Name": "lower critical",
+                    "Severity": 1,
+                    "Value": 2.45
+                }
+            ],
+            "Type": "ADC"
+        },
+        {
+            "I2CAddress": 91,
+            "I2CBus": 3,
+            "Name": "Power Supply Slot 0",
+            "NamedPresenceGpio": "presence-ps0",
+            "Type": "IBMCFFPSConnector"
+        },
+        {
+            "I2CAddress": 90,
+            "I2CBus": 3,
+            "Name": "Power Supply Slot 1",
+            "NamedPresenceGpio": "presence-ps1",
+            "Type": "IBMCFFPSConnector"
+        },
+        {
+            "Address": "0x64",
+            "Bus": 2,
+            "Name": "UCD90160 Power Sequencer",
+            "Type": "UCD90160"
+        }
+    ],
+    "Name": "Waterloo Backplane",
+    "Probe": [
+        "com.ibm.ipzvpd.VINI({'CC': [50, 69, 52, 54]})"
+    ],
+    "Type": "Board"
+}

--- a/schemas/ibm.json
+++ b/schemas/ibm.json
@@ -48,6 +48,7 @@
                     "type": "array",
                     "items": {
                         "enum": [
+                            "ibm,balcones",
                             "ibm,blueridge",
                             "ibm,blueridge-1s4u",
                             "ibm,blueridge-2u",


### PR DESCRIPTION
Add Balcones and Waterloo configuration, Balcones IM (0x60004000) and Waterloo CCIN (2E46). The configuration files are exact same copy of Bonnell and Pennybacker

Test:
  Built an image and verified balcones.json and waterloo.json exist in
  the image

Change-Id: Id171c35af1f8131d937dcfaa2e37f6cdaada31fd