### PR TITLE
configurations: system1: update ADC threshold and hysteresis

### DIFF
--- a/configurations/system1_baseboard.json
+++ b/configurations/system1_baseboard.json
@@ -8,24 +8,28 @@
             "Thresholds": [
                 {
                     "Direction": "greater than",
+                    "Hysteresis": 0.133,
                     "Name": "upper critical",
                     "Severity": 1,
-                    "Value": 13.0
+                    "Value": 13.3
                 },
                 {
                     "Direction": "greater than",
+                    "Hysteresis": 0.128,
                     "Name": "upper non critical",
                     "Severity": 0,
                     "Value": 12.8
                 },
                 {
                     "Direction": "less than",
+                    "Hysteresis": 0.115,
                     "Name": "lower non critical",
                     "Severity": 0,
-                    "Value": 11.2
+                    "Value": 11.5
                 },
                 {
                     "Direction": "less than",
+                    "Hysteresis": 0.11,
                     "Name": "lower critical",
                     "Severity": 1,
                     "Value": 11.0
@@ -41,24 +45,28 @@
             "Thresholds": [
                 {
                     "Direction": "greater than",
+                    "Hysteresis": 0.0525,
                     "Name": "upper critical",
                     "Severity": 1,
                     "Value": 5.25
                 },
                 {
                     "Direction": "greater than",
+                    "Hysteresis": 0.051500000000000004,
                     "Name": "upper non critical",
                     "Severity": 0,
                     "Value": 5.15
                 },
                 {
                     "Direction": "less than",
+                    "Hysteresis": 0.048499999999999995,
                     "Name": "lower non critical",
                     "Severity": 0,
                     "Value": 4.85
                 },
                 {
                     "Direction": "less than",
+                    "Hysteresis": 0.0475,
                     "Name": "lower critical",
                     "Severity": 1,
                     "Value": 4.75
@@ -74,24 +82,28 @@
             "Thresholds": [
                 {
                     "Direction": "greater than",
+                    "Hysteresis": 0.0525,
                     "Name": "upper critical",
                     "Severity": 1,
                     "Value": 5.25
                 },
                 {
                     "Direction": "greater than",
+                    "Hysteresis": 0.051500000000000004,
                     "Name": "upper non critical",
                     "Severity": 0,
                     "Value": 5.15
                 },
                 {
                     "Direction": "less than",
+                    "Hysteresis": 0.048499999999999995,
                     "Name": "lower non critical",
                     "Severity": 0,
                     "Value": 4.85
                 },
                 {
                     "Direction": "less than",
+                    "Hysteresis": 0.0475,
                     "Name": "lower critical",
                     "Severity": 1,
                     "Value": 4.75
@@ -107,24 +119,28 @@
             "Thresholds": [
                 {
                     "Direction": "greater than",
+                    "Hysteresis": 0.03465,
                     "Name": "upper critical",
                     "Severity": 1,
                     "Value": 3.465
                 },
                 {
                     "Direction": "greater than",
+                    "Hysteresis": 0.03399,
                     "Name": "upper non critical",
                     "Severity": 0,
                     "Value": 3.399
                 },
                 {
                     "Direction": "less than",
+                    "Hysteresis": 0.032010000000000004,
                     "Name": "lower non critical",
                     "Severity": 0,
                     "Value": 3.201
                 },
                 {
                     "Direction": "less than",
+                    "Hysteresis": 0.031349999999999996,
                     "Name": "lower critical",
                     "Severity": 1,
                     "Value": 3.135
@@ -140,27 +156,31 @@
             "Thresholds": [
                 {
                     "Direction": "greater than",
+                    "Hysteresis": 0.0374,
                     "Name": "upper critical",
                     "Severity": 1,
-                    "Value": 3.465
+                    "Value": 3.74
                 },
                 {
                     "Direction": "greater than",
+                    "Hysteresis": 0.0357,
                     "Name": "upper non critical",
                     "Severity": 0,
-                    "Value": 3.399
+                    "Value": 3.57
                 },
                 {
                     "Direction": "less than",
+                    "Hysteresis": 0.0323,
                     "Name": "lower non critical",
                     "Severity": 0,
-                    "Value": 3.201
+                    "Value": 3.23
                 },
                 {
                     "Direction": "less than",
+                    "Hysteresis": 0.0306,
                     "Name": "lower critical",
                     "Severity": 1,
-                    "Value": 3.135
+                    "Value": 3.06
                 }
             ],
             "Type": "ADC"
@@ -173,24 +193,28 @@
             "Thresholds": [
                 {
                     "Direction": "greater than",
+                    "Hysteresis": 0.0189,
                     "Name": "upper critical",
                     "Severity": 1,
                     "Value": 1.89
                 },
                 {
                     "Direction": "greater than",
+                    "Hysteresis": 0.01854,
                     "Name": "upper non critical",
                     "Severity": 0,
                     "Value": 1.854
                 },
                 {
                     "Direction": "less than",
+                    "Hysteresis": 0.01746,
                     "Name": "lower non critical",
                     "Severity": 0,
                     "Value": 1.746
                 },
                 {
                     "Direction": "less than",
+                    "Hysteresis": 0.0171,
                     "Name": "lower critical",
                     "Severity": 1,
                     "Value": 1.71
@@ -206,24 +230,28 @@
             "Thresholds": [
                 {
                     "Direction": "greater than",
+                    "Hysteresis": 0.0126,
                     "Name": "upper critical",
                     "Severity": 1,
                     "Value": 1.26
                 },
                 {
                     "Direction": "greater than",
+                    "Hysteresis": 0.01236,
                     "Name": "upper non critical",
                     "Severity": 0,
                     "Value": 1.236
                 },
                 {
                     "Direction": "less than",
+                    "Hysteresis": 0.01164,
                     "Name": "lower non critical",
                     "Severity": 0,
                     "Value": 1.164
                 },
                 {
                     "Direction": "less than",
+                    "Hysteresis": 0.011399999999999999,
                     "Name": "lower critical",
                     "Severity": 1,
                     "Value": 1.14
@@ -239,27 +267,31 @@
             "Thresholds": [
                 {
                     "Direction": "greater than",
+                    "Hysteresis": 0.0145,
                     "Name": "upper critical",
                     "Severity": 1,
-                    "Value": 1.26
+                    "Value": 1.45
                 },
                 {
                     "Direction": "greater than",
+                    "Hysteresis": 0.0135,
                     "Name": "upper non critical",
                     "Severity": 0,
-                    "Value": 1.236
+                    "Value": 1.35
                 },
                 {
                     "Direction": "less than",
+                    "Hysteresis": 0.0115,
                     "Name": "lower non critical",
                     "Severity": 0,
-                    "Value": 1.164
+                    "Value": 1.15
                 },
                 {
                     "Direction": "less than",
+                    "Hysteresis": 0.011,
                     "Name": "lower critical",
                     "Severity": 1,
-                    "Value": 1.14
+                    "Value": 1.1
                 }
             ],
             "Type": "ADC"
@@ -272,27 +304,31 @@
             "Thresholds": [
                 {
                     "Direction": "greater than",
+                    "Hysteresis": 0.0145,
                     "Name": "upper critical",
                     "Severity": 1,
-                    "Value": 1.26
+                    "Value": 1.45
                 },
                 {
                     "Direction": "greater than",
+                    "Hysteresis": 0.0135,
                     "Name": "upper non critical",
                     "Severity": 0,
-                    "Value": 1.236
+                    "Value": 1.35
                 },
                 {
                     "Direction": "less than",
+                    "Hysteresis": 0.0115,
                     "Name": "lower non critical",
                     "Severity": 0,
-                    "Value": 1.164
+                    "Value": 1.15
                 },
                 {
                     "Direction": "less than",
+                    "Hysteresis": 0.011,
                     "Name": "lower critical",
                     "Severity": 1,
-                    "Value": 1.14
+                    "Value": 1.1
                 }
             ],
             "Type": "ADC"
@@ -305,24 +341,28 @@
             "Thresholds": [
                 {
                     "Direction": "greater than",
+                    "Hysteresis": 0.02625,
                     "Name": "upper critical",
                     "Severity": 1,
                     "Value": 2.625
                 },
                 {
                     "Direction": "greater than",
+                    "Hysteresis": 0.025750000000000002,
                     "Name": "upper non critical",
                     "Severity": 0,
                     "Value": 2.575
                 },
                 {
                     "Direction": "less than",
+                    "Hysteresis": 0.024249999999999997,
                     "Name": "lower non critical",
                     "Severity": 0,
                     "Value": 2.425
                 },
                 {
                     "Direction": "less than",
+                    "Hysteresis": 0.02375,
                     "Name": "lower critical",
                     "Severity": 1,
                     "Value": 2.375


### PR DESCRIPTION
System1 should utilize the same thresholds and hysteresis ADC values as sbp1. Update to match the latest sbp1 values.

Tested:
- Put on system1 and verified expected thresholds and no errors in web
  interface

Change-Id: Ie8cba2eee37dc6d856295625a6d12d512bed9053