### PR TITLE
Spdm tcp responder schema

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -105,6 +105,7 @@ schemas = [
     'leak_detector.json',
     'firmware.json',
     'supported_configuration.json',
+    'spdm_responder.json',
 ]
 
 foreach s : schemas

--- a/schemas/global.json
+++ b/schemas/global.json
@@ -32,6 +32,9 @@
                     "$ref": "satellite_controller.json#/$defs/SatelliteController"
                 },
                 {
+                    "$ref": "spdm.json#/definitions/Responder"
+                },
+                {
                     "$ref": "stepwise.json#/$defs/Stepwise"
                 },
                 {

--- a/schemas/spdm_responder.json
+++ b/schemas/spdm_responder.json
@@ -1,0 +1,22 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "definitions": {
+        "Responder": {
+            "title": "SPDM TCP responder configuration",
+            "description": "The configuration used to add remote SPDM responder to the system",
+            "type": "object",
+            "properties": {
+                "Hostname": {
+                    "description": "Hostname or IP of SPDM TCP responder",
+                    "type": "string"
+                },
+                "Port": {
+                    "description": "Network port SPDM TCP responder is listening on per DSP0287_1.0.0",
+                    "type": "number"
+                }
+            },
+            "required": ["Hostname", "Port"]
+        }
+    }
+}
+


### PR DESCRIPTION
This schema will be utilized to add SPDM Tcp Responders to the user system.

More information on SPDM Tcp Responder can be found at [1].

Tested:
- Confirmed a system utilizing new schema worked as expected

[1]: https://github.com/openbmc/docs/blob/master/designs/redfish-spdm-attestation.md