### PR TITLE
config: Add Balcones Efficient Power Mode

### DIFF
--- a/configurations/balcones.json
+++ b/configurations/balcones.json
@@ -9,12 +9,27 @@
             "Type": "IBMCompatibleSystem"
         },
         {
+            "CustomerModes": [
+                "PowerSaving",
+                "MaximumPerformance",
+                "EfficiencyFavorPower"
+            ],
+            "EcoModeSupport": true,
             "EnterUtilizationDwellTime": 240,
             "EnterUtilizationPercent": 8,
             "ExitUtilizationDwellTime": 10,
             "ExitUtilizationPercent": 12,
             "IdlePowerSaverEnabled": true,
             "Name": "Default Power Mode Properties",
+            "OemModes": [
+                "BalancedPerformance",
+                "EfficiencyFavorPerformance",
+                "FFO",
+                "MaxFrequency",
+                "NonDeterministic",
+                "SFP",
+                "Static"
+            ],
             "PowerMode": "MaximumPerformance",
             "Type": "PowerModeProperties"
         },


### PR DESCRIPTION
add CustomerModes:EfficiencyFavorPower to enable power mode.

Tested:
     Did overlay on BMC, updated balcones.json file.  Killed entity manger, 
     Killed occ-control. verified in occ-control traces. booted system and 
     changed mode to  Efficient Power Mode