### PR TITLE
configurations: Add IBM's Huygens chassis

### DIFF
--- a/configurations/huygens_chassis.json
+++ b/configurations/huygens_chassis.json
@@ -1,0 +1,38 @@
+{
+    "Exposes": [
+        {
+            "CustomerModes": [
+                "PowerSaving",
+                "MaximumPerformance",
+                "EfficiencyFavorPower"
+            ],
+            "EnterUtilizationDwellTime": 240,
+            "EnterUtilizationPercent": 8,
+            "ExitUtilizationDwellTime": 10,
+            "ExitUtilizationPercent": 12,
+            "IdlePowerSaverEnabled": false,
+            "Name": "Default Power Mode Properties",
+            "OemModes": [
+                "BalancedPerformance",
+                "EfficiencyFavorPerformance",
+                "FFO",
+                "MaxFrequency",
+                "NonDeterministic",
+                "SFP",
+                "Static"
+            ],
+            "PowerMode": "MaximumPerformance",
+            "Type": "PowerModeProperties"
+        }
+    ],
+    "Name": "Huygens System Chassis",
+    "Probe": [
+        "com.ibm.ipzvpd.VSBP({'IM': [112, 0, 16, 0]})"
+    ],
+    "Type": "Chassis",
+    "xyz.openbmc_project.Inventory.Decorator.Compatible": {
+        "Names": [
+            "com.ibm.Hardware.Chassis.Model.Huygens"
+        ]
+    }
+}

--- a/configurations/meson.build
+++ b/configurations/meson.build
@@ -58,6 +58,7 @@ configs = [
     'genesis3_chassis.json',
     'genesis3_psu.json',
     'gospower_g1136-1300wna_psu.json',
+    'huygens_chassis.json',
     'ibm_tacoma_rack_controller.json',
     'ingraham.json',
     'intel_front_panel.json',


### PR DESCRIPTION
This represents the highest level chassis, of which there is one.


Change-Id: I2abfc4732654a6b0592559c56aacd96f38f4b515