### PR TITLE
Change rbmc-prototype to use 2U chassis

### DIFF
--- a/configurations/meson.build
+++ b/configurations/meson.build
@@ -172,7 +172,7 @@ configs = [
     'rainier_1s4u_chassis.json',
     'rainier_2u_chassis.json',
     'rainier_4u_chassis.json',
-    'rbmc_prototype_4u_chassis.json',
+    'rbmc_prototype_2u_chassis.json',
     'sas_module.json',
     'sbp1_baseboard.json',
     'sbp1_chassis.json',

--- a/configurations/rbmc_prototype_2u_chassis.json
+++ b/configurations/rbmc_prototype_2u_chassis.json
@@ -27,17 +27,30 @@
         },
         {
             "InputVoltage": [
+                110,
                 220
             ],
-            "Name": "1400W 1600W IBMCFFPS Configuration",
-            "PowerConfigFullLoad": true,
-            "RedundantCount": 4,
-            "SupportedModel": "2B1E",
+            "Name": "1000W IBMCFFPS Configuration",
+            "PowerConfigFullLoad": false,
+            "RedundantCount": 2,
+            "SupportedModel": "51ED",
+            "SupportedType": "PowerSupply",
+            "Type": "SupportedConfiguration"
+        },
+        {
+            "InputVoltage": [
+                110,
+                220
+            ],
+            "Name": "2000W IBMCFFPS Configuration",
+            "PowerConfigFullLoad": false,
+            "RedundantCount": 2,
+            "SupportedModel": "51E9",
             "SupportedType": "PowerSupply",
             "Type": "SupportedConfiguration"
         }
     ],
-    "Name": "RBMC Prototype Rainier 4U Chassis",
+    "Name": "RBMC Prototype Rainier 2U Chassis",
     "Probe": [
         "com.ibm.ipzvpd.VSBP({'IM': [118, 0, 32, 0]})"
     ],
@@ -45,7 +58,7 @@
     "xyz.openbmc_project.Inventory.Decorator.Compatible": {
         "Names": [
             "com.ibm.Hardware.Chassis.Model.RBMCPrototype",
-            "com.ibm.Hardware.Chassis.Model.Rainier4U",
+            "com.ibm.Hardware.Chassis.Model.Rainier2U",
             "com.ibm.Hardware.Chassis.Model.Rainier"
         ]
     }


### PR DESCRIPTION
The rbmc-prototype systems use the Rainier 2U chassis, not 4U.


Change-Id: I40dcc272ea414b7dfc9c2a373493a118ef15c4ab