### PR TITLE
schemas: SPDM TCP responder schema

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -102,6 +102,7 @@ schemas = [
     'stepwise.json',
     'virtual_sensor.json',
     'satellite_controller.json',
+    'spdm_endpoint.json',
     'leak_detector.json',
     'firmware.json',
     'supported_configuration.json',

--- a/schemas/global.json
+++ b/schemas/global.json
@@ -32,6 +32,9 @@
                     "$ref": "satellite_controller.json#/$defs/SatelliteController"
                 },
                 {
+                    "$ref": "spdm_endpoint.json#/$defs/SpdmTcpResponder"
+                },
+                {
                     "$ref": "stepwise.json#/$defs/Stepwise"
                 },
                 {

--- a/schemas/spdm_endpoint.json
+++ b/schemas/spdm_endpoint.json
@@ -1,0 +1,41 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$defs": {
+        "SpdmTcpEndpoint": {
+            "title": "SPDM TCP responder configuration",
+            "description": "The configuration used to add remote SPDM responder to the system",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "Hostname": {
+                    "description": "Hostname or IP of remote SPDM TCP responder",
+                    "type": "string"
+                },
+                "Port": {
+                    "description": "Network port SPDM TCP responder is listening on per DSP0287_1.0.0",
+                    "type": "number"
+                },
+                "TrustedComponentType": {
+                    "description": "Type of the Root of Trust",
+                    "enum": ["discrete", "integrated"]
+                },
+                "Name": {
+                    "description": "The name of the object",
+                    "type": "string"
+                },
+                "Type": {
+                    "description": "The type of object",
+                    "type": "string",
+                    "enum": ["SpdmTcpResponder"]
+                }
+            },
+            "required": [
+                "Hostname",
+                "Port",
+                "TrustedComponentType",
+                "Name",
+                "Type"
+            ]
+        }
+    }
+}


### PR DESCRIPTION
This schema will be utilized to add remote SPDM TCP Responder to the user system.

The SPDM-over-TCP design details are found at [1].

Tested:
- Confirmed a system utilizing new schema worked as expected

[1]: https://github.com/openbmc/docs/blob/master/designs/redfish-spdm-attestation.md

Change-Id: I42f0c70040660f5f391765aa4f21c62a83a363be