### PR TITLE
configuration: Add SPDM TCP responder to IBM Huygens system

### DIFF
--- a/configurations/huygens_bmc.json
+++ b/configurations/huygens_bmc.json
@@ -1,0 +1,21 @@
+{
+    "Exposes": [
+        {
+            "Hostname": "$ManagementAddressIPv4",
+            "Name": "Peer BMC Spdm Responder $index",
+            "Port": 4194,
+            "TrustedComponentType": "discrete",
+            "Type": "SpdmTcpResponder"
+        }
+    ],
+    "Name": "Huygens BMC Peer",
+    "Probe": [
+        "xyz.openbmc_project.Network.LLDP.TLVs({'ExchangeType': 'xyz.openbmc_project.Network.LLDP.TLVs.LLDPExchangeType.Receive'})",
+        "AND",
+        "xyz.openbmc_project.Network.LLDP.TLVs({'SystemDescription': 'BMC'})",
+        "MATCH_ONE",
+        "AND",
+        "FOUND('Huygens System Chassis')"
+    ],
+    "Type": "Board"
+}

--- a/configurations/meson.build
+++ b/configurations/meson.build
@@ -58,6 +58,7 @@ configs = [
     'genesis3_chassis.json',
     'genesis3_psu.json',
     'gospower_g1136-1300wna_psu.json',
+    'huygens_bmc.json',
     'huygens_chassis.json',
     'huygens_node.json',
     'ibm_tacoma_rack_controller.json',

--- a/meson.build
+++ b/meson.build
@@ -102,6 +102,7 @@ schemas = [
     'stepwise.json',
     'virtual_sensor.json',
     'satellite_controller.json',
+    'spdm_endpoint.json',
     'leak_detector.json',
     'firmware.json',
     'supported_configuration.json',

--- a/schemas/global.json
+++ b/schemas/global.json
@@ -31,6 +31,9 @@
                 {
                     "$ref": "satellite_controller.json#/$defs/SatelliteController"
                 },
+		{
+                    "$ref": "spdm_endpoint.json#/$defs/SpdmTcpEndpoint"
+		},
                 {
                     "$ref": "stepwise.json#/$defs/Stepwise"
                 },

--- a/schemas/spdm_endpoint.json
+++ b/schemas/spdm_endpoint.json
@@ -1,0 +1,41 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$defs": {
+        "SpdmTcpEndpoint": {
+            "title": "SPDM TCP responder configuration",
+            "description": "The configuration used to add remote SPDM responder to the system",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "Hostname": {
+                    "description": "Hostname or IP of remote SPDM TCP responder",
+                    "type": "string"
+                },
+                "Port": {
+                    "description": "Network port SPDM TCP responder is listening on per DSP0287_1.0.0",
+                    "type": "number"
+                },
+                "TrustedComponentType": {
+                    "description": "Type of the Root of Trust",
+                    "enum": ["discrete", "integrated"]
+                },
+                "Name": {
+                    "description": "The name of the object",
+                    "type": "string"
+                },
+                "Type": {
+                    "description": "The type of object",
+                    "type": "string",
+                    "enum": ["SpdmTcpResponder"]
+                }
+            },
+            "required": [
+                "Hostname",
+                "Port",
+                "TrustedComponentType",
+                "Name",
+                "Type"
+            ]
+        }
+    }
+}


### PR DESCRIPTION
Adding the schema and configuration for SPDM TCP responder

IBM Huygens is the system with redundant BMC support. The peer BMC is discovered via ethernet protocol LLDP that enables devices to advertise and exchange information with their neighbors on a network. LLDP daemon will populate the peer details as defined in this PDI [1] and [2]. Network daemon service is implementing LLDP interfaces [3].

Huygens system utilizes TCP SPDM daemon to provide interface for peer device attestation. Discovery of TCP SPDM devices is done through EM configuration [4].

Creating an EM configuration to look for lldp interface with exchange type as "receive" and system description as "BMC". HostName or IPAddress is taken from the lldp interface and port number is hardcoded as mentioned in DSP287[5].

SPDM commit [6] uses SpdmTcpResponder interface for discovery of responder.

Tested:
- Built into image and verified:
  - Entity manager created "SpdmTcpResponder" object
  - xyz.openbmc_project.Configuration.SpdmTcpResponder was on D-Bus with expected properties

[1] https://gerrit.openbmc.org/c/openbmc/phosphor-dbus-interfaces/+/83533
[2] https://gerrit.openbmc.org/c/openbmc/phosphor-dbus-interfaces/+/85057
[3] https://gerrit.openbmc.org/c/openbmc/phosphor-networkd/+/84119
[4] https://github.com/openbmc/docs/blob/master/designs/redfish-spdm-attestation.md
[5] https://www.dmtf.org/sites/default/files/standards/documents/DSP0287_1.0.0.pdf
[6] https://github.com/openbmc/spdm/commit/c15aeec7e7598eecb2940f2ce0ffad7c2b594c8b
Change-Id: Ia96e3d39a6d8bad62b426b9d529ca32a88a3d571