### PR TITLE
entity-mgr: Add Position decorator

### DIFF
--- a/configurations/loggerhead.json
+++ b/configurations/loggerhead.json
@@ -19,5 +19,9 @@
     "Probe": [
         "com.ibm.ipzvpd.VINI({'CC': [50, 70, 50, 48]})"
     ],
-    "Type": "Board"
+    "Type": "Board",
+
+    "xyz.openbmc_project.Inventory.Decorator.Position": {
+        "Position": "$bus / 100"
+    }
 }

--- a/schemas/global.json
+++ b/schemas/global.json
@@ -136,6 +136,9 @@
                 "xyz.openbmc_project.Inventory.Decorator.ManagedHost": {
                     "$ref": "openbmc-dbus.json#/$defs/xyz/openbmc_project/Inventory/Decorator/ManagedHost"
                 },
+                "xyz.openbmc_project.Inventory.Decorator.Position": {
+                    "$ref": "openbmc-dbus.json#/$defs/xyz/openbmc_project/Inventory/Decorator/Position"
+                },
                 "xyz.openbmc_project.Inventory.Decorator.Replaceable": {
                     "$ref": "openbmc-dbus.json#/$defs/xyz/openbmc_project/Inventory/Decorator/Replaceable"
                 },

--- a/schemas/openbmc-dbus.json
+++ b/schemas/openbmc-dbus.json
@@ -82,6 +82,16 @@
                             "required": ["Length", "Type"],
                             "type": "object"
                         },
+                        "Position": {
+                            "additionalProperties": false,
+                            "properties": {
+                                "Position": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": ["Position"],
+                            "type": "object"
+                        },
                         "Replaceable": {
                             "additionalProperties": false,
                             "properties": {


### PR DESCRIPTION
Added the "xyz.openbmc_project.Inventory.Decorator.Position" interface to the entity-manager configuration. The new Position field is populated using and expression based on $bus, enabling dynamic position assignments tied to the device's bus index.

Tested:
  - Applied entity-manager changes on Huygens; restarted entity-manager and inventory-manager.
  - Observed Position values match expected mapping for Loggerhead backplane.

Change-Id: Id30f324af7efdda738a7ad7b7f60b221ac10a940