### PR TITLE
configuration: Add SPDM TCP responder to rBMC prototype systems

### DIFF
--- a/configurations/meson.build
+++ b/configurations/meson.build
@@ -176,6 +176,7 @@ configs = [
     'rainier_2u_chassis.json',
     'rainier_4u_chassis.json',
     'rbmc_prototype_2u_chassis.json',
+    'rbmc_prototype_bmc.json',
     'sas_module.json',
     'sbp1_baseboard.json',
     'sbp1_chassis.json',

--- a/configurations/rbmc_prototype_bmc.json
+++ b/configurations/rbmc_prototype_bmc.json
@@ -1,0 +1,21 @@
+{
+    "Exposes": [
+        {
+            "Hostname": "$ManagementAddressIPv4",
+            "Name": "Peer BMC Spdm Responder $index",
+            "Port": 4194,
+            "TrustedComponentType": "discrete",
+            "Type": "SpdmTcpResponder"
+        }
+    ],
+    "Name": "Huygens BMC Peer",
+    "Probe": [
+        "xyz.openbmc_project.Network.LLDP.TLVs({'ExchangeType': 'xyz.openbmc_project.Network.LLDP.TLVs.LLDPExchangeType.Receive'})",
+        "AND",
+        "xyz.openbmc_project.Network.LLDP.TLVs({'SystemDescription': 'BMC'})",
+        "MATCH_ONE",
+        "AND",
+        "FOUND('RBMC Prototype Rainier 2U Chassis')"
+    ],
+    "Type": "Board"
+}


### PR DESCRIPTION
Adding configuration for SPDM TCP responder to rBMC prototype systems